### PR TITLE
FIX - 로그인 쿠키 관련 에러 처리

### DIFF
--- a/src/components/user/AuthenticationButton.tsx
+++ b/src/components/user/AuthenticationButton.tsx
@@ -8,7 +8,15 @@ function AuthenticationButton() {
   return (
     <>
       {isLoggedIn() ? (
-        <p onClick={logout}>Logout</p>
+        <p
+          onClick={() => {
+            logout().then(() => {
+              location.reload();
+            });
+          }}
+        >
+          Logout
+        </p>
       ) : (
         <>
           <Link to={'/login'}>Login</Link>

--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -41,6 +41,7 @@ function useApi({ useLoading = true }: UseApiProps = {}) {
     if (useLoading) setIsLoading(false);
     if (error.response.status === 403) {
       alert('로그인이 필요합니다.');
+      document.cookie = 'isLoggedIn=;';
       navigate('/login');
     }
     return Promise.reject(error);

--- a/src/hooks/useAuthentication.tsx
+++ b/src/hooks/useAuthentication.tsx
@@ -11,15 +11,14 @@ function useAuthentication() {
   };
 
   const logout = () => {
-    userApi
+    return userApi
       .post('/logout')
       .then(() => {
         document.cookie = 'isLoggedIn=;';
       })
       .catch(() => {
         alert('Logout Failed!');
-      })
-      .finally(() => navigate('/'));
+      });
   };
 
   const login = (userId: string, userPassword: string) => {


### PR DESCRIPTION
## 📚 개요

- 로그인 쿠키가 만료되었지만 로그아웃 처리가 되지 않아서 로그인 된 것 처럼 보이는 문제가 있었다.
- 이를 해결하려고 보니 logout에서 navigate까지 처리하고 있어서 login page로 이동하는 것이 아닌 home으로 이동하고 있었다. 
- navigate의 책임을 logout이 아닌 logout을 사용하는 곳으로 넘기기 위해서 logout에서 Promise를 반환하게 수정했다.
- 또한 쿠키가 만료되었을 때 isLoggedIn 쿠키도 초기화 시켜주었다.

## 🕐 리뷰 예상 시간

> 3m