### PR TITLE
FEAT - 슈퍼어드민 워크스페이스에서 워크스페이스 클릭 시 새로운 탭으로 열리는 기능 추가

### DIFF
--- a/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
+++ b/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
@@ -2,7 +2,6 @@ import { Workspace } from '@@types/index';
 import { SubContainer } from '@components/common/container/AppContainer';
 import styled from '@emotion/styled';
 import { rowFlex } from '@styles/flexStyles';
-import { useNavigate } from 'react-router-dom';
 
 const SubLabelContainer = styled.div`
   color: #d8d8d8;
@@ -24,7 +23,6 @@ const WorkspaceLabel = styled.div`
 `;
 
 function SuperAdminWorkspaceContent({ id, name, owner, createdAt }: Workspace) {
-  const navigate = useNavigate();
   const datePart = createdAt.split('T')[0];
   const filteredCreatedDate = datePart.replace(/-/g, '.');
   const createdDateAndOwnerText = `${filteredCreatedDate} | ${owner.name}`;
@@ -40,7 +38,7 @@ function SuperAdminWorkspaceContent({ id, name, owner, createdAt }: Workspace) {
     >
       <WorkspaceLabel
         onClick={() => {
-          navigate(`/admin/workspace/${id}`);
+          window.open(`${window.location.origin}/admin/workspace/${id}`, '_blank', 'rel=noopener noreferrer popup=false');
         }}
         className={'workspace-label'}
       >


### PR DESCRIPTION
## 📚 개요


https://github.com/user-attachments/assets/9b255a07-b70f-4679-8076-0529c19293b2

- 워크스페이스 라벨을 클릭시 새로운 탭으로 해당 워크스페이스 페이지를 엽니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- useNavigate 대신에 window.open( ) 함수를 사용했습니다.