### PR TITLE
FEAT - 슈퍼어드민 manage 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import ResetPassword from '@pages/User/ResetPassword';
 import Info from '@pages/User/Info';
 import SuperAdminHome from '@pages/SuperAdmin/SuperAdminHome';
 import SuperAdminWorkspace from '@pages/SuperAdmin/SuperAdminWorkspace';
+import SuperAdminManage from '@pages/SuperAdmin/SuperAdminManage';
 
 ReactGA.initialize('G-XGYLSPGK2G');
 function App() {
@@ -51,6 +52,7 @@ function App() {
         <Route path="/super-admin/home" element={<SuperAdminHome />} />
         <Route path="/admin/workspace/:workspaceId" element={<AdminWorkspace />} />
         <Route path="/super-admin/workspace" element={<SuperAdminWorkspace />} />
+        <Route path="/super-admin/manage" element={<SuperAdminManage />} />
         <Route path="/admin/workspace/:workspaceId/orders" element={<AdminOrder />} />
         <Route path="/admin/workspace/:workspaceId/orders-history" element={<AdminOrderHistory />} />
         <Route path="/admin/workspace/:workspaceId/orders-manage" element={<AdminOrderManage />} />

--- a/src/components/common/button/ImageRouteButton.tsx
+++ b/src/components/common/button/ImageRouteButton.tsx
@@ -44,7 +44,7 @@ function ImageRouteButton(props: ImageRouteButtonProps) {
   return (
     <Container src={props.src} className={'image-route-button-container'}>
       <SubContainer className={'image-route-sub-container'}>
-        <AppLabel size={30} style={{ color: 'white', fontWeight: 600, textShadow: '0 4px 4px rgba(0, 0, 0, 0.25)' }}>
+        <AppLabel size={25} style={{ color: 'white', fontWeight: 600, textShadow: '0 4px 4px rgba(0, 0, 0, 0.25)' }}>
           {props.buttonText}
         </AppLabel>
         <RouteButton type={'button'} onClick={props.onClick} className={'route-button'}>

--- a/src/pages/Admin/AdminWorkspace.tsx
+++ b/src/pages/Admin/AdminWorkspace.tsx
@@ -20,7 +20,7 @@ const Container = styled.div`
   ${colFlex({ align: 'center' })}
 `;
 
-const ButtonContainer = styled.div`
+export const ButtonContainer = styled.div`
   gap: 30px;
   ${rowFlex()}
 `;

--- a/src/pages/SuperAdmin/SuperAdminHome.tsx
+++ b/src/pages/SuperAdmin/SuperAdminHome.tsx
@@ -80,7 +80,7 @@ function SuperAdminHome() {
           키오스쿨로
           <br /> 주점관리를 손쉽게,
         </MainTitle>
-        <LinkAdminHome to={'/admin'} onMouseEnter={() => setIsHover(true)} onMouseLeave={() => setIsHover(false)} className={'link-admin-home'}>
+        <LinkAdminHome to={'/super-admin/manage'} onMouseEnter={() => setIsHover(true)} onMouseLeave={() => setIsHover(false)} className={'link-admin-home'}>
           <LinkText className={'link-text'}>
             SUPER ADMIN
             <ArrowRight />

--- a/src/pages/SuperAdmin/SuperAdminHome.tsx
+++ b/src/pages/SuperAdmin/SuperAdminHome.tsx
@@ -16,7 +16,7 @@ const MainTitle = styled.div`
   margin-bottom: 24px;
 `;
 
-const LinkAdminHome = styled(Link)`
+const LinkSuperAdminHome = styled(Link)`
   text-decoration: none;
   z-index: 1001;
   width: 349px;
@@ -80,12 +80,17 @@ function SuperAdminHome() {
           키오스쿨로
           <br /> 주점관리를 손쉽게,
         </MainTitle>
-        <LinkAdminHome to={'/super-admin/manage'} onMouseEnter={() => setIsHover(true)} onMouseLeave={() => setIsHover(false)} className={'link-admin-home'}>
+        <LinkSuperAdminHome
+          to={'/super-admin/manage'}
+          onMouseEnter={() => setIsHover(true)}
+          onMouseLeave={() => setIsHover(false)}
+          className={'link-admin-home'}
+        >
           <LinkText className={'link-text'}>
             SUPER ADMIN
             <ArrowRight />
           </LinkText>
-        </LinkAdminHome>
+        </LinkSuperAdminHome>
         <AppFooter />
         <HoverOverlay isHover={isHover} className={'hover-overlay'} />
       </>

--- a/src/pages/SuperAdmin/SuperAdminManage.tsx
+++ b/src/pages/SuperAdmin/SuperAdminManage.tsx
@@ -1,0 +1,5 @@
+function SuperAdminManage() {
+  return <h1>this is super admin manage page</h1>;
+}
+
+export default SuperAdminManage;

--- a/src/pages/SuperAdmin/SuperAdminManage.tsx
+++ b/src/pages/SuperAdmin/SuperAdminManage.tsx
@@ -1,5 +1,30 @@
+import ImageRouteButton from '@components/common/button/ImageRouteButton';
+import AppContainer from '@components/common/container/AppContainer';
+import TitleNavBar from '@components/common/nav/TitleNavBar';
+import styled from '@emotion/styled';
+import { ButtonContainer } from '@pages/Admin/AdminWorkspace';
+import orderImage from '@resources/image/orderImage.png';
+import { colFlex } from '@styles/flexStyles';
+import { useNavigate } from 'react-router-dom';
+
+const Container = styled.div`
+  width: 100%;
+  ${colFlex({ justify: 'center', align: 'center' })}
+`;
+
 function SuperAdminManage() {
-  return <h1>this is super admin manage page</h1>;
+  const navigate = useNavigate();
+  return (
+    <AppContainer contentsJustify={'center'}>
+      <Container>
+        <TitleNavBar title={'관리 페이지'} />
+        <ButtonContainer>
+          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/workspace')} buttonText={'워크스페이스 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/user')} buttonText={'사용자 조회'} />
+        </ButtonContainer>
+      </Container>
+    </AppContainer>
+  );
 }
 
 export default SuperAdminManage;

--- a/src/pages/SuperAdmin/SuperAdminManage.tsx
+++ b/src/pages/SuperAdmin/SuperAdminManage.tsx
@@ -2,14 +2,18 @@ import ImageRouteButton from '@components/common/button/ImageRouteButton';
 import AppContainer from '@components/common/container/AppContainer';
 import TitleNavBar from '@components/common/nav/TitleNavBar';
 import styled from '@emotion/styled';
-import { ButtonContainer } from '@pages/Admin/AdminWorkspace';
 import orderImage from '@resources/image/orderImage.png';
-import { colFlex } from '@styles/flexStyles';
+import { colFlex, rowFlex } from '@styles/flexStyles';
 import { useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   width: 100%;
   ${colFlex({ align: 'center' })}
+`;
+
+const ButtonContainer = styled.div`
+  gap: 30px;
+  ${rowFlex()}
 `;
 
 function SuperAdminManage() {

--- a/src/pages/SuperAdmin/SuperAdminManage.tsx
+++ b/src/pages/SuperAdmin/SuperAdminManage.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   width: 100%;
-  ${colFlex({ justify: 'center', align: 'center' })}
+  ${colFlex({ align: 'center' })}
 `;
 
 function SuperAdminManage() {
@@ -21,6 +21,7 @@ function SuperAdminManage() {
         <ButtonContainer>
           <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/workspace')} buttonText={'워크스페이스 조회'} />
           <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/user')} buttonText={'사용자 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/email')} buttonText={'이메일 조회'} />
         </ButtonContainer>
       </Container>
     </AppContainer>


### PR DESCRIPTION
## 📚 개요

https://github.com/user-attachments/assets/d0e459d0-498c-4984-a46f-abd2e0b7bdd0

- 슈퍼어드민 home에서 manage 페이지로 이동할 수 있는 링크 추가했습니다.
- 슈퍼어드민 manage 페이지의 전체적인 프레임을 구성했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- ImageRouteButton 및 해당 컨테이너에 대해 추후 공용 컴포넌트에 추가할 예정입니다.
- titleNavBar에 대한 새로운 디자인을 추가 적용할 예정입니다.