### PR TITLE
FEAT - 서버 요청 시 짧은 Response에 대해 로딩창 보여주지 않기

### DIFF
--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -11,6 +11,7 @@ function useApi() {
 
   const setLoadingFalse = (key: any) => {
     const timeOutId = map.get(key);
+    map.delete(key);
     clearTimeout(timeOutId);
 
     if (!map.size) setIsLoading(false);

--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -9,7 +9,15 @@ function useApi() {
   const controller = new AbortController();
   const map = new Map();
 
-  const setLoadingFalse = (key: any) => {
+  const startLoading = (key: any) => {
+    const timeOutId = setTimeout(() => {
+      setIsLoading(true);
+    }, 500);
+
+    map.set(key, timeOutId);
+  };
+
+  const stopLoading = (key: any) => {
     const timeOutId = map.get(key);
     map.delete(key);
     clearTimeout(timeOutId);
@@ -24,28 +32,23 @@ function useApi() {
   });
 
   const commonRequestInterceptor = (config: any) => {
-    const timeOutId = setTimeout(() => {
-      setIsLoading(true);
-    }, 500);
-
-    map.set(config, timeOutId);
-
+    startLoading(config);
     return config;
   };
 
   const commonResponseInterceptor = (response: any) => {
-    setLoadingFalse(response.config);
+    stopLoading(response.config);
     return response;
   };
 
   const commonErrorInterceptor = (error: any) => {
-    setLoadingFalse(error.config);
+    stopLoading(error.config);
     return Promise.reject(error);
   };
 
   adminApi.interceptors.request.use(commonRequestInterceptor, commonErrorInterceptor);
   adminApi.interceptors.response.use(commonResponseInterceptor, (error) => {
-    setLoadingFalse(error.config);
+    stopLoading(error.config);
 
     if (error.response.status === 403) {
       controller.abort();
@@ -72,7 +75,7 @@ function useApi() {
 
   superAdminApi.interceptors.request.use(commonRequestInterceptor, commonErrorInterceptor);
   superAdminApi.interceptors.response.use(commonResponseInterceptor, (error) => {
-    setLoadingFalse(error.config);
+    stopLoading(error.config);
 
     if (error.response.status === 403) {
       controller.abort();

--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -9,6 +9,13 @@ function useApi() {
   const controller = new AbortController();
   const map = new Map();
 
+  const setLoadingFalse = (key: any) => {
+    const timeOutId = map.get(key);
+    clearTimeout(timeOutId);
+
+    if (!map.size) setIsLoading(false);
+  };
+
   const adminApi = axios.create({
     baseURL: process.env.REACT_APP_ENVIRONMENT == 'development' ? 'http://localhost:8080/admin' : 'https://kio-school.fly.dev/admin',
     withCredentials: true,
@@ -26,26 +33,18 @@ function useApi() {
   };
 
   const commonResponseInterceptor = (response: any) => {
-    const timeOutId = map.get(response.config);
-    clearTimeout(timeOutId);
-    setIsLoading(false);
-
+    setLoadingFalse(response.config);
     return response;
   };
 
   const commonErrorInterceptor = (error: any) => {
-    const timeOutId = map.get(error.config);
-    clearTimeout(timeOutId);
-    setIsLoading(false);
-
+    setLoadingFalse(error.config);
     return Promise.reject(error);
   };
 
   adminApi.interceptors.request.use(commonRequestInterceptor, commonErrorInterceptor);
   adminApi.interceptors.response.use(commonResponseInterceptor, (error) => {
-    const timeOutId = map.get(error.config);
-    clearTimeout(timeOutId);
-    setIsLoading(false);
+    setLoadingFalse(error.config);
 
     if (error.response.status === 403) {
       controller.abort();
@@ -72,9 +71,7 @@ function useApi() {
 
   superAdminApi.interceptors.request.use(commonRequestInterceptor, commonErrorInterceptor);
   superAdminApi.interceptors.response.use(commonResponseInterceptor, (error) => {
-    const timeOutId = map.get(error.config);
-    clearTimeout(timeOutId);
-    setIsLoading(false);
+    setLoadingFalse(error.config);
 
     if (error.response.status === 403) {
       controller.abort();

--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -3,14 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { isLoadingAtom } from '@recoils/atoms';
 
-interface UseApiProps {
-  useLoading?: boolean;
-}
-
-function useApi({ useLoading = true }: UseApiProps = {}) {
+function useApi() {
   const navigate = useNavigate();
   const setIsLoading = useSetRecoilState(isLoadingAtom);
   const controller = new AbortController();
+  const map = new Map();
 
   const adminApi = axios.create({
     baseURL: process.env.REACT_APP_ENVIRONMENT == 'development' ? 'http://localhost:8080/admin' : 'https://kio-school.fly.dev/admin',
@@ -19,23 +16,37 @@ function useApi({ useLoading = true }: UseApiProps = {}) {
   });
 
   const commonRequestInterceptor = (config: any) => {
-    if (useLoading) setIsLoading(true);
+    const timeOutId = setTimeout(() => {
+      setIsLoading(true);
+    }, 500);
+
+    map.set(config, timeOutId);
+
     return config;
   };
 
   const commonResponseInterceptor = (response: any) => {
-    if (useLoading) setIsLoading(false);
+    const timeOutId = map.get(response.config);
+    clearTimeout(timeOutId);
+    setIsLoading(false);
+
     return response;
   };
 
   const commonErrorInterceptor = (error: any) => {
-    if (useLoading) setIsLoading(false);
+    const timeOutId = map.get(error.config);
+    clearTimeout(timeOutId);
+    setIsLoading(false);
+
     return Promise.reject(error);
   };
 
   adminApi.interceptors.request.use(commonRequestInterceptor, commonErrorInterceptor);
   adminApi.interceptors.response.use(commonResponseInterceptor, (error) => {
-    if (useLoading) setIsLoading(false);
+    const timeOutId = map.get(error.config);
+    clearTimeout(timeOutId);
+    setIsLoading(false);
+
     if (error.response.status === 403) {
       controller.abort();
       alert('로그인이 필요합니다.');
@@ -61,7 +72,10 @@ function useApi({ useLoading = true }: UseApiProps = {}) {
 
   superAdminApi.interceptors.request.use(commonRequestInterceptor, commonErrorInterceptor);
   superAdminApi.interceptors.response.use(commonResponseInterceptor, (error) => {
-    if (useLoading) setIsLoading(false);
+    const timeOutId = map.get(error.config);
+    clearTimeout(timeOutId);
+    setIsLoading(false);
+
     if (error.response.status === 403) {
       controller.abort();
       alert('권한이 없습니다.');


### PR DESCRIPTION
## 📚 개요
### BEFORE

https://github.com/user-attachments/assets/73aa6d93-cfd4-45c9-83d1-a1ab1eb23fa5


### AFTER



https://github.com/user-attachments/assets/b1f07e53-163b-447b-ac5a-737c1d10d753



setTimeOut( ) 함수를 이용해, 500ms 이상 걸리는 요청에만 로딩창을 보여주도록 했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)