### PR TITLE
FEAT - 색상 관련 const enum 적용

### DIFF
--- a/src/components/SuperAdmin/user/SuperAdminUserContent.tsx
+++ b/src/components/SuperAdmin/user/SuperAdminUserContent.tsx
@@ -1,6 +1,7 @@
 import { User } from '@@types/index';
 import { SubContainer } from '@components/common/container/AppContainer';
 import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 
 const SubLabelContainer = styled.div`
@@ -17,7 +18,7 @@ const WorkspaceLabel = styled.div`
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {
-    color: #eb6d09;
+    color: ${Color.kioOrange};
     text-decoration: underline;
   }
 `;

--- a/src/components/SuperAdmin/user/SuperAdminUserContent.tsx
+++ b/src/components/SuperAdmin/user/SuperAdminUserContent.tsx
@@ -18,7 +18,7 @@ const WorkspaceLabel = styled.div`
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {
-    color: ${Color.kioOrange};
+    color: ${Color.KIO_ORANGE};
     text-decoration: underline;
   }
 `;

--- a/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
+++ b/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
@@ -1,6 +1,7 @@
 import { Workspace } from '@@types/index';
 import { SubContainer } from '@components/common/container/AppContainer';
 import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 
 const SubLabelContainer = styled.div`
@@ -13,7 +14,7 @@ const WorkspaceLabel = styled.div`
   font-size: 18px;
   font-weight: 400;
   text-decoration: none;
-  color: #5c5c5c;
+  color: ${Color.grey};
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {

--- a/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
+++ b/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
@@ -18,7 +18,7 @@ const WorkspaceLabel = styled.div`
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {
-    color: ${Color.kioOrange};
+    color: ${Color.KIO_ORANGE};
     text-decoration: underline;
   }
 `;

--- a/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
+++ b/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
@@ -14,7 +14,7 @@ const WorkspaceLabel = styled.div`
   font-size: 18px;
   font-weight: 400;
   text-decoration: none;
-  color: ${Color.grey};
+  color: ${Color.GREY};
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {

--- a/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
+++ b/src/components/SuperAdmin/workspace/SuperAdminWorkspaceContent.tsx
@@ -18,7 +18,7 @@ const WorkspaceLabel = styled.div`
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {
-    color: #eb6d09;
+    color: ${Color.kioOrange};
     text-decoration: underline;
   }
 `;

--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -44,7 +44,7 @@ const Button = styled.button`
   width: 80px;
   height: 30px;
   border: none;
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   color: ${Color.white};
   cursor: pointer;
   border-radius: 50px;

--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -44,8 +44,8 @@ const Button = styled.button`
   width: 80px;
   height: 30px;
   border: none;
-  background: ${Color.kioOrange};
-  color: ${Color.white};
+  background: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
   cursor: pointer;
   border-radius: 50px;
   &:hover {

--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -6,6 +6,7 @@ import useAdminOrder from '@hooks/admin/useAdminOrder';
 import AppLabel from '@components/common/label/AppLabel';
 import HorizontalDivider from '@components/common/divider/HorizontalDivider';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface Props {
   order: Order;
@@ -44,7 +45,7 @@ const Button = styled.button`
   height: 30px;
   border: none;
   background: #eb6d09;
-  color: white;
+  color: ${Color.white};
   cursor: pointer;
   border-radius: 50px;
   &:hover {

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -39,8 +39,8 @@ const Button = styled.button`
   width: 80px;
   height: 30px;
   border: none;
-  background: ${Color.kioOrange};
-  color: ${Color.white};
+  background: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
   cursor: pointer;
   border-radius: 50px;
   &:hover {

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -7,6 +7,7 @@ import AppLabel from '@components/common/label/AppLabel';
 import HorizontalDivider from '@components/common/divider/HorizontalDivider';
 import AppCheckBox from '@components/common/input/AppCheckBox';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface Props {
   order: Order;
@@ -39,7 +40,7 @@ const Button = styled.button`
   height: 30px;
   border: none;
   background: #eb6d09;
-  color: white;
+  color: ${Color.white};
   cursor: pointer;
   border-radius: 50px;
   &:hover {

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -39,7 +39,7 @@ const Button = styled.button`
   width: 80px;
   height: 30px;
   border: none;
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   color: ${Color.white};
   cursor: pointer;
   border-radius: 50px;

--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -32,7 +32,7 @@ const Button = styled.button`
   width: 80px;
   height: 30px;
   border: none;
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   color: ${Color.white};
   cursor: pointer;
   border-radius: 50px;

--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -32,8 +32,8 @@ const Button = styled.button`
   width: 80px;
   height: 30px;
   border: none;
-  background: ${Color.kioOrange};
-  color: ${Color.white};
+  background: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
   cursor: pointer;
   border-radius: 50px;
   &:hover {

--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -6,6 +6,7 @@ import HorizontalDivider from '@components/common/divider/HorizontalDivider';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import { useParams } from 'react-router-dom';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface Props {
   order: Order;
@@ -32,7 +33,7 @@ const Button = styled.button`
   height: 30px;
   border: none;
   background: #eb6d09;
-  color: white;
+  color: ${Color.white};
   cursor: pointer;
   border-radius: 50px;
   &:hover {

--- a/src/components/admin/product-category/CategoryDraggableContents.tsx
+++ b/src/components/admin/product-category/CategoryDraggableContents.tsx
@@ -2,6 +2,7 @@ import { ProductCategory } from '@@types/index';
 import styled from '@emotion/styled';
 import useAdminProducts from '@hooks/admin/useAdminProducts';
 import useConfirm from '@hooks/useConfirm';
+import { Color } from '@resources/colors';
 import DeleteButtonGraySvg from '@resources/svg/DeleteButtonGraySvg';
 import DragIconSvg from '@resources/svg/DragIconSvg';
 import { rowFlex } from '@styles/flexStyles';
@@ -17,7 +18,7 @@ const CategoryItemContainer = styled.div`
 const CategoryContentsContainer = styled.div`
   width: 500px;
   height: 60px;
-  background-color: white;
+  background-color: ${Color.white};
   border-radius: 12px;
   box-shadow: 0 4px 17px 0 rgba(0, 0, 0, 0.1);
   margin: 10px 0;

--- a/src/components/admin/product-category/CategoryDraggableContents.tsx
+++ b/src/components/admin/product-category/CategoryDraggableContents.tsx
@@ -18,7 +18,7 @@ const CategoryItemContainer = styled.div`
 const CategoryContentsContainer = styled.div`
   width: 500px;
   height: 60px;
-  background-color: ${Color.white};
+  background-color: ${Color.WHITE};
   border-radius: 12px;
   box-shadow: 0 4px 17px 0 rgba(0, 0, 0, 0.1);
   margin: 10px 0;

--- a/src/components/admin/workspace/WorkspaceContent.tsx
+++ b/src/components/admin/workspace/WorkspaceContent.tsx
@@ -13,17 +13,17 @@ const WorkspaceContainer = styled.div`
   width: 321px;
   height: 332px;
   border-radius: 25px;
-  background: ${Color.kioOrange};
+  background: ${Color.KIO_ORANGE};
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
   ${colFlex({ justify: 'space-between', align: 'flex-start' })}
 
   &:hover {
-    background: linear-gradient(140deg, #ffe3cc -165.17%, ${Color.kioOrange} 92.63%);
+    background: linear-gradient(140deg, #ffe3cc -165.17%, ${Color.KIO_ORANGE} 92.63%);
   }
 
   &:active {
     border-radius: 25px;
-    background: ${Color.kioOrange};
+    background: ${Color.KIO_ORANGE};
     box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.25) inset;
   }
 `;

--- a/src/components/admin/workspace/WorkspaceContent.tsx
+++ b/src/components/admin/workspace/WorkspaceContent.tsx
@@ -6,23 +6,24 @@ import useConfirm from '@hooks/useConfirm';
 import DeleteButtonSvg from '@resources/svg/DeleteButtonSvg';
 import React from 'react';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 const WorkspaceContainer = styled.div`
   cursor: pointer;
   width: 321px;
   height: 332px;
   border-radius: 25px;
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
   ${colFlex({ justify: 'space-between', align: 'flex-start' })}
 
   &:hover {
-    background: linear-gradient(140deg, #ffe3cc -165.17%, #eb6d09 92.63%);
+    background: linear-gradient(140deg, #ffe3cc -165.17%, ${Color.kioOrange} 92.63%);
   }
 
   &:active {
     border-radius: 25px;
-    background: #eb6d09;
+    background: ${Color.kioOrange};
     box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.25) inset;
   }
 `;

--- a/src/components/common/badge/AppBadge.tsx
+++ b/src/components/common/badge/AppBadge.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
 
 interface AppBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
   background?: string;
@@ -16,7 +17,7 @@ const Container = styled.div`
   text-align: center;
   line-height: 30px;
   font-size: 15px;
-  background: ${(props: AppBadgeProps) => props.background || 'white'};
+  background: ${(props: AppBadgeProps) => props.background || Color.white};
   user-select: none;
   white-space: nowrap;
 

--- a/src/components/common/badge/AppBadge.tsx
+++ b/src/components/common/badge/AppBadge.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
   text-align: center;
   line-height: 30px;
   font-size: 15px;
-  background: ${(props: AppBadgeProps) => props.background || Color.white};
+  background: ${(props: AppBadgeProps) => props.background || Color.WHITE};
   user-select: none;
   white-space: nowrap;
 

--- a/src/components/common/button/AppButton.tsx
+++ b/src/components/common/button/AppButton.tsx
@@ -17,8 +17,8 @@ const Container = styled.button`
     if (typeof props.size === 'number') return `${props.size}px`;
     return sizeMap[props.size || 'medium'];
   }};
-  background: ${Color.kioOrange};
-  color: ${Color.white};
+  background: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
   font-size: 18px;
   border: none;
   border-radius: 15px;

--- a/src/components/common/button/AppButton.tsx
+++ b/src/components/common/button/AppButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
 
 export interface AppButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size?: 'small' | 'medium' | 'large' | number;
@@ -17,7 +18,7 @@ const Container = styled.button`
     return sizeMap[props.size || 'medium'];
   }};
   background: #eb6d09;
-  color: white;
+  color: ${Color.white};
   font-size: 18px;
   border: none;
   border-radius: 15px;

--- a/src/components/common/button/AppButton.tsx
+++ b/src/components/common/button/AppButton.tsx
@@ -17,7 +17,7 @@ const Container = styled.button`
     if (typeof props.size === 'number') return `${props.size}px`;
     return sizeMap[props.size || 'medium'];
   }};
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   color: ${Color.white};
   font-size: 18px;
   border: none;

--- a/src/components/common/button/ImageRouteButton.tsx
+++ b/src/components/common/button/ImageRouteButton.tsx
@@ -19,7 +19,7 @@ const Container = styled.div<{ src: string }>`
   ${colFlex({ justify: 'flex-end' })}
 
   &:hover {
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #eb6d09 120%), url(${(props) => props.src});
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, ${Color.kioOrange} 120%), url(${(props) => props.src});
   }
 `;
 

--- a/src/components/common/button/ImageRouteButton.tsx
+++ b/src/components/common/button/ImageRouteButton.tsx
@@ -19,7 +19,7 @@ const Container = styled.div<{ src: string }>`
   ${colFlex({ justify: 'flex-end' })}
 
   &:hover {
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, ${Color.kioOrange} 120%), url(${(props) => props.src});
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, ${Color.KIO_ORANGE} 120%), url(${(props) => props.src});
   }
 `;
 
@@ -36,7 +36,7 @@ const RouteButton = styled.button`
   border: 1px solid #fff;
   border-radius: 8px;
   font-size: 16px;
-  color: ${Color.white};
+  color: ${Color.WHITE};
   cursor: pointer;
   backdrop-filter: blur(8px);
 `;
@@ -45,7 +45,7 @@ function ImageRouteButton(props: ImageRouteButtonProps) {
   return (
     <Container src={props.src} className={'image-route-button-container'}>
       <SubContainer className={'image-route-sub-container'}>
-        <AppLabel size={25} style={{ color: Color.white, fontWeight: 600, textShadow: '0 4px 4px rgba(0, 0, 0, 0.25)' }}>
+        <AppLabel size={25} style={{ color: Color.WHITE, fontWeight: 600, textShadow: '0 4px 4px rgba(0, 0, 0, 0.25)' }}>
           {props.buttonText}
         </AppLabel>
         <RouteButton type={'button'} onClick={props.onClick} className={'route-button'}>

--- a/src/components/common/button/ImageRouteButton.tsx
+++ b/src/components/common/button/ImageRouteButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import AppLabel from '@components/common/label/AppLabel';
 import { colFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface ImageRouteButtonProps {
   src: string;
@@ -35,7 +36,7 @@ const RouteButton = styled.button`
   border: 1px solid #fff;
   border-radius: 8px;
   font-size: 16px;
-  color: white;
+  color: ${Color.white};
   cursor: pointer;
   backdrop-filter: blur(8px);
 `;
@@ -44,7 +45,7 @@ function ImageRouteButton(props: ImageRouteButtonProps) {
   return (
     <Container src={props.src} className={'image-route-button-container'}>
       <SubContainer className={'image-route-sub-container'}>
-        <AppLabel size={25} style={{ color: 'white', fontWeight: 600, textShadow: '0 4px 4px rgba(0, 0, 0, 0.25)' }}>
+        <AppLabel size={25} style={{ color: Color.white, fontWeight: 600, textShadow: '0 4px 4px rgba(0, 0, 0, 0.25)' }}>
           {props.buttonText}
         </AppLabel>
         <RouteButton type={'button'} onClick={props.onClick} className={'route-button'}>

--- a/src/components/common/button/RoundedAppButton.tsx
+++ b/src/components/common/button/RoundedAppButton.tsx
@@ -8,7 +8,7 @@ export interface RoundedAppButtonProps extends React.ButtonHTMLAttributes<HTMLBu
 
 const Container = styled.button`
   width: ${(props: RoundedAppButtonProps) => props.size};
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   color: ${Color.white};
   font-size: 15px;
   border: none;

--- a/src/components/common/button/RoundedAppButton.tsx
+++ b/src/components/common/button/RoundedAppButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
 
 export interface RoundedAppButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size?: string;
@@ -8,7 +9,7 @@ export interface RoundedAppButtonProps extends React.ButtonHTMLAttributes<HTMLBu
 const Container = styled.button`
   width: ${(props: RoundedAppButtonProps) => props.size};
   background: #eb6d09;
-  color: white;
+  color: ${Color.white};
   font-size: 15px;
   border: none;
   border-radius: 20px;

--- a/src/components/common/button/RoundedAppButton.tsx
+++ b/src/components/common/button/RoundedAppButton.tsx
@@ -8,8 +8,8 @@ export interface RoundedAppButtonProps extends React.ButtonHTMLAttributes<HTMLBu
 
 const Container = styled.button`
   width: ${(props: RoundedAppButtonProps) => props.size};
-  background: ${Color.kioOrange};
-  color: ${Color.white};
+  background: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
   font-size: 15px;
   border: none;
   border-radius: 20px;

--- a/src/components/common/button/SwitchButton.tsx
+++ b/src/components/common/button/SwitchButton.tsx
@@ -27,8 +27,8 @@ const Container = styled.div`
 `;
 
 const Circle = styled.div<{ checked: boolean }>`
-  background-color: ${(props) => (props.checked ? Color.kioOrange : Color.white)};
-  color: ${(props) => (props.checked ? Color.white : 'black')};
+  background-color: ${(props) => (props.checked ? Color.KIO_ORANGE : Color.WHITE)};
+  color: ${(props) => (props.checked ? Color.WHITE : 'black')};
   width: 38px;
   height: 38px;
   border-radius: 50px;

--- a/src/components/common/button/SwitchButton.tsx
+++ b/src/components/common/button/SwitchButton.tsx
@@ -27,7 +27,7 @@ const Container = styled.div`
 `;
 
 const Circle = styled.div<{ checked: boolean }>`
-  background-color: ${(props) => (props.checked ? '#eb6d09' : Color.white)};
+  background-color: ${(props) => (props.checked ? Color.kioOrange : Color.white)};
   color: ${(props) => (props.checked ? Color.white : 'black')};
   width: 38px;
   height: 38px;

--- a/src/components/common/button/SwitchButton.tsx
+++ b/src/components/common/button/SwitchButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface Props {
   checked: boolean;
@@ -26,8 +27,8 @@ const Container = styled.div`
 `;
 
 const Circle = styled.div<{ checked: boolean }>`
-  background-color: ${(props) => (props.checked ? '#eb6d09' : 'white')};
-  color: ${(props) => (props.checked ? 'white' : 'black')};
+  background-color: ${(props) => (props.checked ? '#eb6d09' : Color.white)};
+  color: ${(props) => (props.checked ? Color.white : 'black')};
   width: 38px;
   height: 38px;
   border-radius: 50px;

--- a/src/components/common/container/AppContainer.tsx
+++ b/src/components/common/container/AppContainer.tsx
@@ -3,12 +3,13 @@ import NavBar from '@components/common/nav/NavBar';
 import { colFlex } from '@styles/flexStyles';
 import TitleNavBar, { TitleNavBarProps } from '../nav/TitleNavBar';
 import { SerializedStyles } from '@emotion/react';
+import { Color } from '@resources/colors';
 
 export const MainContainer = styled.div<{ backgroundColor?: string; useScroll?: boolean }>`
   width: 100%;
   height: ${(props) => (props.useScroll ? '100%' : '100vh')};
   box-sizing: border-box;
-  background-color: ${(props) => (props.backgroundColor ? props.backgroundColor : 'white')};
+  background-color: ${(props) => (props.backgroundColor ? props.backgroundColor : Color.white)};
   ${colFlex({ justify: 'center', align: 'center' })}
 `;
 

--- a/src/components/common/container/AppContainer.tsx
+++ b/src/components/common/container/AppContainer.tsx
@@ -9,7 +9,7 @@ export const MainContainer = styled.div<{ backgroundColor?: string; useScroll?: 
   width: 100%;
   height: ${(props) => (props.useScroll ? '100%' : '100vh')};
   box-sizing: border-box;
-  background-color: ${(props) => (props.backgroundColor ? props.backgroundColor : Color.white)};
+  background-color: ${(props) => (props.backgroundColor ? props.backgroundColor : Color.WHITE)};
   ${colFlex({ justify: 'center', align: 'center' })}
 `;
 

--- a/src/components/common/input/AppImageInput.tsx
+++ b/src/components/common/input/AppImageInput.tsx
@@ -28,7 +28,7 @@ const ImageInputButton = styled.label`
   cursor: pointer;
   padding: 5px 10px;
   border-radius: 8px;
-  background-color: #eb6d09;
+  background-color: ${Color.kioOrange};
   color: ${Color.white};
   &:hover {
     background: #ff7b2b;

--- a/src/components/common/input/AppImageInput.tsx
+++ b/src/components/common/input/AppImageInput.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent } from 'react';
 import styled from '@emotion/styled';
 import uploadPreview from '@resources/image/uploadPreview.png';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface ProductImageInputProps {
   title: string;
@@ -28,7 +29,7 @@ const ImageInputButton = styled.label`
   padding: 5px 10px;
   border-radius: 8px;
   background-color: #eb6d09;
-  color: white;
+  color: ${Color.white};
   &:hover {
     background: #ff7b2b;
   }

--- a/src/components/common/input/AppImageInput.tsx
+++ b/src/components/common/input/AppImageInput.tsx
@@ -28,8 +28,8 @@ const ImageInputButton = styled.label`
   cursor: pointer;
   padding: 5px 10px;
   border-radius: 8px;
-  background-color: ${Color.kioOrange};
-  color: ${Color.white};
+  background-color: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
   &:hover {
     background: #ff7b2b;
   }

--- a/src/components/common/input/AppInputWithButton.tsx
+++ b/src/components/common/input/AppInputWithButton.tsx
@@ -8,7 +8,7 @@ import { Color } from '@resources/colors';
 const AppInputWithButtonContainer = styled.div`
   height: 65px;
   width: 420px;
-  background-color: ${Color.white};
+  background-color: ${Color.WHITE};
   border-radius: 12px;
   box-shadow: 0 4px 17px 0 rgba(0, 0, 0, 0.1);
   ${rowFlex({ justify: 'center', align: 'center' })}

--- a/src/components/common/input/AppInputWithButton.tsx
+++ b/src/components/common/input/AppInputWithButton.tsx
@@ -3,11 +3,12 @@ import AppButton from '@components/common/button/AppButton';
 import styled from '@emotion/styled';
 import AppInput from '@components/common/input/AppInput';
 import { rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 const AppInputWithButtonContainer = styled.div`
   height: 65px;
   width: 420px;
-  background-color: white;
+  background-color: ${Color.white};
   border-radius: 12px;
   box-shadow: 0 4px 17px 0 rgba(0, 0, 0, 0.1);
   ${rowFlex({ justify: 'center', align: 'center' })}

--- a/src/components/common/label/AppLabel.tsx
+++ b/src/components/common/label/AppLabel.tsx
@@ -4,7 +4,7 @@ import { Color } from '@resources/colors';
 
 export interface AppLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   size?: 'small' | 'medium' | 'large' | number;
-  color?: string;
+  color?: Color;
 }
 
 const sizeMap = {
@@ -13,7 +13,7 @@ const sizeMap = {
   large: '40px',
 };
 
-const Container = styled.label<{ size?: 'small' | 'medium' | 'large' | number; color?: string }>`
+const Container = styled.label<{ size?: 'small' | 'medium' | 'large' | number; color?: Color }>`
   color: ${(props) => props.color || Color.GREY};
   font-size: ${(props: AppLabelProps) => {
     if (typeof props.size === 'number') return `${props.size}px`;

--- a/src/components/common/label/AppLabel.tsx
+++ b/src/components/common/label/AppLabel.tsx
@@ -4,6 +4,7 @@ import { Color } from '@resources/colors';
 
 export interface AppLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   size?: 'small' | 'medium' | 'large' | number;
+  color?: string;
 }
 
 const sizeMap = {
@@ -12,8 +13,8 @@ const sizeMap = {
   large: '40px',
 };
 
-const Container = styled.label`
-  color: ${Color.grey};
+const Container = styled.label<{ size?: 'small' | 'medium' | 'large' | number; color?: string }>`
+  color: ${(props) => props.color || Color.grey};
   font-size: ${(props: AppLabelProps) => {
     if (typeof props.size === 'number') return `${props.size}px`;
     return sizeMap[props.size || 'medium'];

--- a/src/components/common/label/AppLabel.tsx
+++ b/src/components/common/label/AppLabel.tsx
@@ -14,7 +14,7 @@ const sizeMap = {
 };
 
 const Container = styled.label<{ size?: 'small' | 'medium' | 'large' | number; color?: string }>`
-  color: ${(props) => props.color || Color.grey};
+  color: ${(props) => props.color || Color.GREY};
   font-size: ${(props: AppLabelProps) => {
     if (typeof props.size === 'number') return `${props.size}px`;
     return sizeMap[props.size || 'medium'];

--- a/src/components/common/label/AppLabel.tsx
+++ b/src/components/common/label/AppLabel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
 
 export interface AppLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   size?: 'small' | 'medium' | 'large' | number;
@@ -12,7 +13,7 @@ const sizeMap = {
 };
 
 const Container = styled.label`
-  color: #5c5c5c;
+  color: ${Color.grey};
   font-size: ${(props: AppLabelProps) => {
     if (typeof props.size === 'number') return `${props.size}px`;
     return sizeMap[props.size || 'medium'];

--- a/src/components/common/workspace/modal/CreateWorkspaceModal.tsx
+++ b/src/components/common/workspace/modal/CreateWorkspaceModal.tsx
@@ -18,7 +18,7 @@ const ModalContent = styled.form`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: ${Color.white};
+  background-color: ${Color.WHITE};
   border-radius: 25px;
   padding: 20px;
   z-index: 1010;

--- a/src/components/common/workspace/modal/CreateWorkspaceModal.tsx
+++ b/src/components/common/workspace/modal/CreateWorkspaceModal.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
 import { colFlex } from '@styles/flexStyles';
 import { FormEventHandler, MouseEventHandler } from 'react';
 
@@ -17,7 +18,7 @@ const ModalContent = styled.form`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: white;
+  background-color: ${Color.white};
   border-radius: 25px;
   padding: 20px;
   z-index: 1010;

--- a/src/components/user/order/OrderButton.tsx
+++ b/src/components/user/order/OrderButton.tsx
@@ -21,7 +21,7 @@ const OrderButtonContainer = styled.div`
 const OrderButtonSubContainer = styled.div`
   padding: 8px;
   border-radius: 20px;
-  background: ${Color.white};
+  background: ${Color.WHITE};
   box-shadow: 0 16px 32px 0 rgba(194, 191, 172, 0.6);
 `;
 

--- a/src/components/user/order/OrderButton.tsx
+++ b/src/components/user/order/OrderButton.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import AppButton from '@components/common/button/AppButton';
 import { rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface OrderButtonProps {
   showButton: boolean;
@@ -20,7 +21,7 @@ const OrderButtonContainer = styled.div`
 const OrderButtonSubContainer = styled.div`
   padding: 8px;
   border-radius: 20px;
-  background: white;
+  background: ${Color.white};
   box-shadow: 0 16px 32px 0 rgba(194, 191, 172, 0.6);
 `;
 

--- a/src/components/user/product/ProductDialog.tsx
+++ b/src/components/user/product/ProductDialog.tsx
@@ -7,6 +7,7 @@ import { useSetRecoilState } from 'recoil';
 import { orderBasketAtom } from '@recoils/atoms';
 import CloseSvg from '@resources/svg/CloseSvg';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface ProductDialogProps {
   product: Product;
@@ -39,7 +40,7 @@ const ModalContainer = styled.div`
   width: 250px;
   height: 270px;
   padding: 5px;
-  background: white;
+  background: ${Color.white};
   border-radius: 16px;
   ${colFlex()}
 `;
@@ -48,7 +49,7 @@ const CloseButtonContainer = styled.div`
   position: absolute;
   right: 15px;
   top: 10px;
-  background: white;
+  background: ${Color.white};
   opacity: 0.7;
   border-radius: 4px;
   ${rowFlex()}

--- a/src/components/user/product/ProductDialog.tsx
+++ b/src/components/user/product/ProductDialog.tsx
@@ -40,7 +40,7 @@ const ModalContainer = styled.div`
   width: 250px;
   height: 270px;
   padding: 5px;
-  background: ${Color.white};
+  background: ${Color.WHITE};
   border-radius: 16px;
   ${colFlex()}
 `;
@@ -49,7 +49,7 @@ const CloseButtonContainer = styled.div`
   position: absolute;
   right: 15px;
   top: 10px;
-  background: ${Color.white};
+  background: ${Color.WHITE};
   opacity: 0.7;
   border-radius: 4px;
   ${rowFlex()}

--- a/src/hooks/useConfirm.tsx
+++ b/src/hooks/useConfirm.tsx
@@ -25,7 +25,7 @@ const SubContainer = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  color: ${Color.white};
+  color: ${Color.WHITE};
 `;
 
 const TextContainer = styled.div`
@@ -71,10 +71,10 @@ function useConfirm(title: string, description: string, okText: string, cancelTe
       <Container className={'confirm-container'}>
         <SubContainer className={'confirm-sub-container'}>
           <TextContainer className={'text-container'}>
-            <AppLabel size={'large'} style={{ fontWeight: 700 }} color={Color.white}>
+            <AppLabel size={'large'} style={{ fontWeight: 700 }} color={Color.WHITE}>
               {title}
             </AppLabel>
-            <AppLabel size={24} color={Color.white}>
+            <AppLabel size={24} color={Color.WHITE}>
               {description}
             </AppLabel>
           </TextContainer>

--- a/src/hooks/useConfirm.tsx
+++ b/src/hooks/useConfirm.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import AppLabel from '@components/common/label/AppLabel';
 import React from 'react';
 import AppButton from '@components/common/button/AppButton';
+import { Color } from '@resources/colors';
 
 const Container = styled.div`
   z-index: 1002;
@@ -24,7 +25,7 @@ const SubContainer = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  color: white;
+  color: ${Color.white};
 `;
 
 const TextContainer = styled.div`

--- a/src/hooks/useConfirm.tsx
+++ b/src/hooks/useConfirm.tsx
@@ -71,10 +71,12 @@ function useConfirm(title: string, description: string, okText: string, cancelTe
       <Container className={'confirm-container'}>
         <SubContainer className={'confirm-sub-container'}>
           <TextContainer className={'text-container'}>
-            <AppLabel size={'large'} style={{ fontWeight: 700 }}>
+            <AppLabel size={'large'} style={{ fontWeight: 700 }} color={Color.white}>
               {title}
             </AppLabel>
-            <AppLabel size={24}>{description}</AppLabel>
+            <AppLabel size={24} color={Color.white}>
+              {description}
+            </AppLabel>
           </TextContainer>
           <ButtonContainer className={'button-container'}>
             {cancelText && (

--- a/src/pages/Admin/order/AdminOrder.tsx
+++ b/src/pages/Admin/order/AdminOrder.tsx
@@ -34,7 +34,7 @@ const OrderColumnContainer = styled.div`
 `;
 
 const OrderHeader = styled.div`
-  background: ${Color.white};
+  background: ${Color.WHITE};
   position: sticky;
   top: 0;
   width: 350px;
@@ -72,7 +72,7 @@ const ProductCard = styled.div`
   width: 160px;
   padding: 5px;
   box-sizing: border-box;
-  background: ${Color.white};
+  background: ${Color.WHITE};
   border-radius: 10px;
   gap: 5px;
   ${colFlex({ justify: 'center', align: 'center' })}

--- a/src/pages/Admin/order/AdminOrder.tsx
+++ b/src/pages/Admin/order/AdminOrder.tsx
@@ -16,6 +16,7 @@ import uploadPreview from '@resources/image/uploadPreview.png';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import AppContainer from '@components/common/container/AppContainer';
 import { OrderStatus } from '@@types/index';
+import { Color } from '@resources/colors';
 
 const KanbanContainer = styled.div`
   width: 100%;
@@ -33,7 +34,7 @@ const OrderColumnContainer = styled.div`
 `;
 
 const OrderHeader = styled.div`
-  background: white;
+  background: ${Color.white};
   position: sticky;
   top: 0;
   width: 350px;
@@ -71,7 +72,7 @@ const ProductCard = styled.div`
   width: 160px;
   padding: 5px;
   box-sizing: border-box;
-  background: white;
+  background: ${Color.white};
   border-radius: 10px;
   gap: 5px;
   ${colFlex({ justify: 'center', align: 'center' })}

--- a/src/pages/Admin/order/AdminOrderManage.tsx
+++ b/src/pages/Admin/order/AdminOrderManage.tsx
@@ -51,14 +51,14 @@ const TableLink = styled.a`
   font-weight: bold;
   color: ${Color.WHITE};
   padding: 5px 10px;
-  background: ${Color.kioOrange};
+  background: ${Color.KIO_ORANGE};
   border-radius: 10px;
 `;
 
 const QRCodeDownloadButton = styled.label`
   width: 100px;
   height: 30px;
-  border: 1px solid ${Color.kioOrange};
+  border: 1px solid ${Color.KIO_ORANGE};
   border-radius: 10px;
   cursor: pointer;
   user-select: none;

--- a/src/pages/Admin/order/AdminOrderManage.tsx
+++ b/src/pages/Admin/order/AdminOrderManage.tsx
@@ -49,7 +49,7 @@ const QRCodeCard = styled.div`
 
 const TableLink = styled.a`
   font-weight: bold;
-  color: ${Color.white};
+  color: ${Color.WHITE};
   padding: 5px 10px;
   background: ${Color.kioOrange};
   border-radius: 10px;

--- a/src/pages/Admin/order/AdminOrderManage.tsx
+++ b/src/pages/Admin/order/AdminOrderManage.tsx
@@ -51,14 +51,14 @@ const TableLink = styled.a`
   font-weight: bold;
   color: ${Color.white};
   padding: 5px 10px;
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   border-radius: 10px;
 `;
 
 const QRCodeDownloadButton = styled.label`
   width: 100px;
   height: 30px;
-  border: 1px solid #eb6d09;
+  border: 1px solid ${Color.kioOrange};
   border-radius: 10px;
   cursor: pointer;
   user-select: none;

--- a/src/pages/Admin/order/AdminOrderManage.tsx
+++ b/src/pages/Admin/order/AdminOrderManage.tsx
@@ -8,6 +8,7 @@ import { DeviceFrameset } from 'react-device-frameset';
 import 'react-device-frameset/styles/marvel-devices.min.css';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import AdminOrderManageTitleNavBarChildren from '../AdminOrderManageTitleNavBarChildren';
+import { Color } from '@resources/colors';
 
 const Container = styled.div`
   width: 100vw;
@@ -48,7 +49,7 @@ const QRCodeCard = styled.div`
 
 const TableLink = styled.a`
   font-weight: bold;
-  color: white;
+  color: ${Color.white};
   padding: 5px 10px;
   background: #eb6d09;
   border-radius: 10px;

--- a/src/pages/User/Home.tsx
+++ b/src/pages/User/Home.tsx
@@ -23,11 +23,11 @@ const LinkAdminHome = styled(Link)`
   width: 349px;
   height: 80px;
   border-radius: 50px;
-  background: ${Color.kioOrange};
+  background: ${Color.KIO_ORANGE};
   ${rowFlex({ align: 'center', justify: 'center' })}
 
   &:hover {
-    background: linear-gradient(133deg, #ff9f32, ${Color.kioOrange});
+    background: linear-gradient(133deg, #ff9f32, ${Color.KIO_ORANGE});
   }
 `;
 

--- a/src/pages/User/Home.tsx
+++ b/src/pages/User/Home.tsx
@@ -6,6 +6,7 @@ import ArrowRight from '@resources/svg/ArrowRightSvg';
 import { css } from '@emotion/react';
 import AppFooter from '@components/common/footer/AppFooter';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 const MainTitle = styled.div`
   width: 540px;
@@ -22,11 +23,11 @@ const LinkAdminHome = styled(Link)`
   width: 349px;
   height: 80px;
   border-radius: 50px;
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   ${rowFlex({ align: 'center', justify: 'center' })}
 
   &:hover {
-    background: linear-gradient(133deg, #ff9f32, #eb6d09);
+    background: linear-gradient(133deg, #ff9f32, ${Color.kioOrange});
   }
 `;
 

--- a/src/pages/User/Info.tsx
+++ b/src/pages/User/Info.tsx
@@ -32,7 +32,7 @@ const Label = styled.div`
 const LinkButton = styled.button`
   width: 200px;
   background: ${Color.kioOrange};
-  color: ${Color.white};
+  color: ${Color.WHITE};
   font-size: 23px;
   font-weight: 800;
   border: none;

--- a/src/pages/User/Info.tsx
+++ b/src/pages/User/Info.tsx
@@ -31,7 +31,7 @@ const Label = styled.div`
 
 const LinkButton = styled.button`
   width: 200px;
-  background: #eb6d09;
+  background: ${Color.kioOrange};
   color: ${Color.white};
   font-size: 23px;
   font-weight: 800;

--- a/src/pages/User/Info.tsx
+++ b/src/pages/User/Info.tsx
@@ -31,7 +31,7 @@ const Label = styled.div`
 
 const LinkButton = styled.button`
   width: 200px;
-  background: ${Color.kioOrange};
+  background: ${Color.KIO_ORANGE};
   color: ${Color.WHITE};
   font-size: 23px;
   font-weight: 800;

--- a/src/pages/User/Info.tsx
+++ b/src/pages/User/Info.tsx
@@ -9,6 +9,7 @@ import infoImage6 from '@resources/image/myInfoImage6.png';
 import AppFooter from '@components/common/footer/AppFooter';
 import NavBar from '@components/common/nav/NavBar';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 const InfoContainer = styled.div`
   width: 100%;
@@ -31,7 +32,7 @@ const Label = styled.div`
 const LinkButton = styled.button`
   width: 200px;
   background: #eb6d09;
-  color: white;
+  color: ${Color.white};
   font-size: 23px;
   font-weight: 800;
   border: none;

--- a/src/pages/User/order/Order.tsx
+++ b/src/pages/User/order/Order.tsx
@@ -14,6 +14,7 @@ import OrderButton from '@components/user/order/OrderButton';
 import useProduct from '@hooks/user/useProduct';
 import AppFooter from '@components/common/footer/AppFooter';
 import { colFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 const Container = styled.div`
   width: 100vw;
@@ -22,7 +23,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: white;
+  background: ${Color.white};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/pages/User/order/Order.tsx
+++ b/src/pages/User/order/Order.tsx
@@ -23,7 +23,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: ${Color.white};
+  background: ${Color.WHITE};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/pages/User/order/OrderBasket.tsx
+++ b/src/pages/User/order/OrderBasket.tsx
@@ -31,7 +31,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: ${Color.white};
+  background: ${Color.WHITE};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/pages/User/order/OrderBasket.tsx
+++ b/src/pages/User/order/OrderBasket.tsx
@@ -9,6 +9,7 @@ import ProductCounterBadge from '@components/user/product/ProductCounterBadge';
 import _ from 'lodash';
 import OrderButton from '@components/user/order/OrderButton';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 const Container = styled.div`
   width: 100vw;
@@ -30,7 +31,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: white;
+  background: ${Color.white};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/pages/User/order/OrderComplete.tsx
+++ b/src/pages/User/order/OrderComplete.tsx
@@ -12,6 +12,7 @@ import AppButton from '@components/common/button/AppButton';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { OrderStatus } from '@@types/index';
 import OrderButton from '@components/user/order/OrderButton';
+import { Color } from '@resources/colors';
 
 const Container = styled.div`
   width: 100vw;
@@ -20,7 +21,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: white;
+  background: ${Color.white};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/pages/User/order/OrderComplete.tsx
+++ b/src/pages/User/order/OrderComplete.tsx
@@ -21,7 +21,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: ${Color.white};
+  background: ${Color.WHITE};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/pages/User/order/OrderPay.tsx
+++ b/src/pages/User/order/OrderPay.tsx
@@ -30,7 +30,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: ${Color.white};
+  background: ${Color.WHITE};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/pages/User/order/OrderPay.tsx
+++ b/src/pages/User/order/OrderPay.tsx
@@ -10,6 +10,7 @@ import AppInputWithLabel from '@components/common/input/AppInputWithLabel';
 import { createSearchParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import useOrder from '@hooks/user/useOrder';
+import { Color } from '@resources/colors';
 
 const Container = styled.div`
   width: 100vw;
@@ -29,7 +30,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  background: white;
+  background: ${Color.white};
   position: sticky;
   top: 0;
   width: 100vw;

--- a/src/resources/colors.tsx
+++ b/src/resources/colors.tsx
@@ -1,6 +1,6 @@
 export const enum Color {
-  'grey' = '#5c5c5c',
-  'white' = 'white',
-  'black' = 'black',
-  'kioOrange' = '#EB6D09'
+  GREY = '#5c5c5c',
+  WHITE = 'white',
+  BLACK = 'black',
+  KIO_ORANGE = '#EB6D09',
 }

--- a/src/resources/colors.tsx
+++ b/src/resources/colors.tsx
@@ -1,0 +1,6 @@
+export const enum Color {
+  'grey' = '#5c5c5c',
+  'white' = 'white',
+  'black' = 'black',
+  'kioOrange' = '#EB6D09'
+}

--- a/src/styles/navBarStyles.tsx
+++ b/src/styles/navBarStyles.tsx
@@ -1,9 +1,11 @@
+import { Color } from '@resources/colors';
+
 export const navBarLabelStyle = `
   text-align: center;
   font-size: 18px;
   font-weight: 400;
   text-decoration: none;
-  color: #5c5c5c;
+  color: ${Color.grey};
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {

--- a/src/styles/navBarStyles.tsx
+++ b/src/styles/navBarStyles.tsx
@@ -5,7 +5,7 @@ export const navBarLabelStyle = `
   font-size: 18px;
   font-weight: 400;
   text-decoration: none;
-  color: ${Color.grey};
+  color: ${Color.GREY};
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {

--- a/src/styles/navBarStyles.tsx
+++ b/src/styles/navBarStyles.tsx
@@ -9,6 +9,6 @@ export const navBarLabelStyle = `
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {
-    color: #eb6d09;
+    color: ${Color.kioOrange};
     text-decoration: underline;
   }`;

--- a/src/styles/navBarStyles.tsx
+++ b/src/styles/navBarStyles.tsx
@@ -9,6 +9,6 @@ export const navBarLabelStyle = `
   cursor: pointer;
   transition: ease-in 0.1s;
   &:hover {
-    color: ${Color.kioOrange};
+    color: ${Color.KIO_ORANGE};
     text-decoration: underline;
   }`;


### PR DESCRIPTION
## 📚 개요

### enum 적용
`export const enum Color {
  'grey' = '#5c5c5c',
  'white' = 'white',
  'black' = 'black',
  'kioOrange' = '#EB6D09'
}

`
<img width="1432" alt="image" src="https://github.com/user-attachments/assets/e8c86586-a7f1-457a-a247-f23c4b1134fd">


## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- 색상에 대하여 const enum을 적용했습니다.
- AppLabel에 color prop을 추가하여 confirm 창의 color를 흰색으로 적용했습니다.