### PR TITLE
ADD - 슈퍼 어드민 이메일 도메인 조회 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import SuperAdminHome from '@pages/SuperAdmin/SuperAdminHome';
 import SuperAdminWorkspace from '@pages/SuperAdmin/SuperAdminWorkspace';
 import SuperAdminManage from '@pages/SuperAdmin/SuperAdminManage';
 import SuperAdminUser from '@pages/SuperAdmin/SuperAdminUser';
+import SuperAdminEmail from '@pages/SuperAdmin/SuperAdminEmail';
 
 ReactGA.initialize('G-XGYLSPGK2G');
 function App() {
@@ -53,6 +54,7 @@ function App() {
         <Route path="/super-admin/home" element={<SuperAdminHome />} />
         <Route path="/admin/workspace/:workspaceId" element={<AdminWorkspace />} />
         <Route path="/super-admin/workspace" element={<SuperAdminWorkspace />} />
+        <Route path="/super-admin/email" element={<SuperAdminEmail />} />
         <Route path="/super-admin/manage" element={<SuperAdminManage />} />
         <Route path="/super-admin/user" element={<SuperAdminUser />} />
         <Route path="/admin/workspace/:workspaceId/orders" element={<AdminOrder />} />

--- a/src/components/SuperAdmin/email/SuperAdminEmailContent.tsx
+++ b/src/components/SuperAdmin/email/SuperAdminEmailContent.tsx
@@ -1,0 +1,37 @@
+import { Email } from '@@types/index';
+import { SubContainer } from '@components/common/container/AppContainer';
+import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
+import { colFlex, rowFlex } from '@styles/flexStyles';
+
+const SubLabelContainer = styled.div`
+  color: #d8d8d8;
+  ${rowFlex()}
+`;
+
+const EmailLabel = styled.div`
+  text-align: center;
+  font-size: 18px;
+  font-weight: 400;
+  text-decoration: none;
+  color: ${Color.GREY};
+  cursor: pointer;
+  transition: ease-in 0.1s;
+  &:hover {
+    color: ${Color.KIO_ORANGE};
+    text-decoration: underline;
+  }
+`;
+
+function SuperAdminEmailContent({ name, domain }: Email) {
+  return (
+    <SubContainer useFlex={colFlex({ justify: 'center', align: 'start' })} customWidth={'1000px'} customHeight={'80px'} customGap={'5px'}>
+      <EmailLabel className={'email-label'}>{name}</EmailLabel>
+      <SubLabelContainer className={'sub-label-container'}>
+        {name} | {domain}
+      </SubLabelContainer>
+    </SubContainer>
+  );
+}
+
+export default SuperAdminEmailContent;

--- a/src/hooks/SuperAdmin/useSuperAdminEmail.tsx
+++ b/src/hooks/SuperAdmin/useSuperAdminEmail.tsx
@@ -1,0 +1,34 @@
+import { Email, PaginationResponse } from '@@types/index';
+import useApi from '@hooks/useApi';
+import { emailPaginationResponseAtom } from '@recoils/atoms';
+import { useSearchParams } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+
+interface FetchAllEmailsParamsType {
+  page: number;
+  size: number;
+  name?: string;
+}
+
+function useSuperAdminEmail() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { superAdminApi } = useApi();
+  const setEmailPaginationResponse = useSetRecoilState(emailPaginationResponseAtom);
+
+  const fetchAllEmails = (page: number, size: number, name?: string) => {
+    const params: FetchAllEmailsParamsType = { page, size, name };
+
+    superAdminApi
+      .get<PaginationResponse<Email>>('/email-domains', { params })
+      .then((res) => {
+        setEmailPaginationResponse(res.data);
+        searchParams.set('page', params.page.toString());
+        setSearchParams(searchParams);
+      })
+      .catch((error) => console.error(error));
+  };
+
+  return { fetchAllEmails };
+}
+
+export default useSuperAdminEmail;

--- a/src/pages/SuperAdmin/SuperAdminEmail.tsx
+++ b/src/pages/SuperAdmin/SuperAdminEmail.tsx
@@ -1,0 +1,58 @@
+import AppContainer from '@components/common/container/AppContainer';
+import Pagination from '@components/common/pagination/Pagination';
+import SuperAdminSearchBar from '@components/SuperAdmin/workspace/SuperAdminSearchBar';
+import styled from '@emotion/styled';
+import { emailPaginationResponseAtom } from '@recoils/atoms';
+import { useEffect, useRef } from 'react';
+import { useRecoilValue } from 'recoil';
+import SuperAdminSearchContents from './SuperAdminSearchContents';
+import useSuperAdminEmail from '@hooks/SuperAdmin/useSuperAdminEmail';
+import { colFlex } from '@styles/flexStyles';
+import SuperAdminEmailContent from '@components/SuperAdmin/email/SuperAdminEmailContent';
+import { useNavigate } from 'react-router-dom';
+
+const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
+  height: 550px;
+  ${(props) =>
+    colFlex({
+      justify: props.justifyCenter ? 'center' : 'flex-start',
+      align: 'center',
+    })}
+`;
+
+function SuperAdminEmail() {
+  const pageSize = 6;
+  const navigate = useNavigate();
+  const userInputRef = useRef<HTMLInputElement | null>(null);
+  const emails = useRecoilValue(emailPaginationResponseAtom);
+  const { fetchAllEmails } = useSuperAdminEmail();
+  const isEmptyEmails = emails.empty;
+  useEffect(() => {
+    fetchAllEmails(0, pageSize);
+  }, []);
+
+  return (
+    <AppContainer
+      useFlex={colFlex({ justify: 'center' })}
+      customWidth={'1000px'}
+      customHeight={'100%'}
+      customGap={'20px'}
+      titleNavBarProps={{ title: '사용자 이메일 관리', onLeftArrowClick: () => navigate('/super-admin/email') }}
+    >
+      <>
+        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAllEmails} />
+        <ContentContainer justifyCenter={isEmptyEmails} className={'content-container'}>
+          <SuperAdminSearchContents contents={emails} target={'이메일'} ContentComponent={SuperAdminEmailContent} />
+        </ContentContainer>
+        <Pagination
+          totalPageCount={emails.totalPages}
+          paginateFunction={(page: number) => {
+            fetchAllEmails(page, pageSize, userInputRef.current?.value);
+          }}
+        />
+      </>
+    </AppContainer>
+  );
+}
+
+export default SuperAdminEmail;

--- a/src/pages/SuperAdmin/SuperAdminEmail.tsx
+++ b/src/pages/SuperAdmin/SuperAdminEmail.tsx
@@ -37,7 +37,7 @@ function SuperAdminEmail() {
       customWidth={'1000px'}
       customHeight={'100%'}
       customGap={'20px'}
-      titleNavBarProps={{ title: '사용자 이메일 관리', onLeftArrowClick: () => navigate('/super-admin/email') }}
+      titleNavBarProps={{ title: '사용자 이메일 관리', onLeftArrowClick: () => navigate('/super-admin/manage') }}
     >
       <>
         <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAllEmails} />

--- a/src/recoils/atoms.ts
+++ b/src/recoils/atoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-import { Order, OrderProductBase, OrderStatus, PaginationResponse, Product, ProductCategory, User, UserRole, Workspace } from '@@types/index';
+import { Email, Order, OrderProductBase, OrderStatus, PaginationResponse, Product, ProductCategory, User, UserRole, Workspace } from '@@types/index';
 
 export const ordersAtom = atom<Order[]>({
   key: 'ordersAtom',
@@ -32,6 +32,7 @@ export const userWorkspaceAtom = atom<Workspace>({
       role: UserRole.ADMIN,
       accountUrl: '',
       id: 0,
+      schoolName: '',
       createdAt: '',
       updatedAt: '',
     },
@@ -51,6 +52,7 @@ export const adminUserAtom = atom<User>({
     role: UserRole.ADMIN,
     accountUrl: '',
     id: 0,
+    schoolName: '',
     createdAt: '',
     updatedAt: '',
   },
@@ -115,6 +117,38 @@ export const workspacePaginationResponseAtom = atom<PaginationResponse<Workspace
 
 export const userPaginationResponseAtom = atom<PaginationResponse<User>>({
   key: 'userPaginationResponseAtom',
+  default: {
+    content: [],
+    pageable: {
+      pageNumber: 0,
+      pageSize: 6,
+      sort: {
+        sorted: false,
+        empty: true,
+        unsorted: true,
+      },
+      offset: 0,
+      paged: true,
+      unpaged: false,
+    },
+    totalPages: 0,
+    totalElements: 0,
+    last: false,
+    number: 0,
+    size: 6,
+    numberOfElements: 0,
+    sort: {
+      sorted: false,
+      empty: true,
+      unsorted: true,
+    },
+    first: true,
+    empty: true,
+  },
+});
+
+export const emailPaginationResponseAtom = atom<PaginationResponse<Email>>({
+  key: 'emailPaginationResponseAtom',
   default: {
     content: [],
     pageable: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,4 +106,13 @@ export interface User {
   id: number;
   createdAt: string;
   updatedAt: string;
+  schoolName: string;
+}
+
+export interface Email {
+  name: string;
+  domain: string;
+  id: number;
+  createdAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
## 📚 개요

슈퍼 어드민 이메일 도메인 조회 페이지 생성
<img width="1403" alt="스크린샷 2024-10-07 오전 12 25 27" src="https://github.com/user-attachments/assets/734937d6-1878-4ae0-961f-4866bcd83fc4">

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- 이메일 도메인 출력과 검색