### PR TITLE
EDIT - TitleNavBar의 height 값을 50px로 고정

### DIFF
--- a/src/components/common/nav/TitleNavBar.tsx
+++ b/src/components/common/nav/TitleNavBar.tsx
@@ -16,7 +16,7 @@ export interface TitleNavBarProps {
 const Container = styled.div<{ useSubTitle: boolean }>`
   z-index: 1002;
   margin-bottom: 25px;
-  height: ${(props) => (props.useSubTitle ? '100px' : '50px')};
+  height: 50px;
   width: 100vw;
   position: fixed;
   top: 61px;


### PR DESCRIPTION
## 📚 개요

### BEFORE

https://github.com/user-attachments/assets/14ef1180-26ed-408a-b56a-e77a1ca12654

### AFTER

https://github.com/user-attachments/assets/35675d13-a495-4092-8564-7d40abf4b4af

- TitleNavBar의 height값을 50px로 고정하여 통일성 있는 디자인을 구현하였습니다.


## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)
