### PR TITLE
REFACTOR - AdminTableCount에서 QRCodeCanvas DOM 접근 방식 재고

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "axios": "1.6.0",
     "jsqr": "^1.4.0",
     "lodash": "^4.17.21",
-    "qrcode.react": "^3.1.0",
+    "qrcode.react": "^4.1.0",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-datepicker": "^6.1.0",

--- a/src/pages/admin/order/AdminTableCount.tsx
+++ b/src/pages/admin/order/AdminTableCount.tsx
@@ -73,7 +73,7 @@ function AdminTableCount() {
   const { fetchWorkspace, updateWorkspaceTableCount } = useAdminWorkspace();
   const setAdminWorkspace = useSetRecoilState(adminWorkspaceAtom);
   const workspace = useRecoilValue(adminWorkspaceAtom);
-  const QRCodeCardRefs = useRef<{ [key: number]: HTMLDivElement | null }>({});
+  const QRCodeCanvasRefs = useRef<{ [key: number]: HTMLCanvasElement | null }>([]);
 
   const [debouncedId, setDebouncedId] = useState<NodeJS.Timeout>();
   const baseUrl = `${location.protocol}//${location.host}`;
@@ -93,13 +93,9 @@ function AdminTableCount() {
   };
 
   const downloadQrCode = (tableNo: number) => {
-    const qrDiv = QRCodeCardRefs.current[tableNo];
-    if (!qrDiv) {
-      return;
-    }
-
-    const canvas = qrDiv.querySelector('canvas') as HTMLCanvasElement;
+    const canvas = QRCodeCanvasRefs.current[tableNo];
     if (!canvas) {
+      alert('다운로드 오류가 발생했습니다!');
       return;
     }
 
@@ -137,9 +133,11 @@ function AdminTableCount() {
                 <TableLink href={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} target={'_blank'}>
                   {index + 1}번 테이블
                 </TableLink>
-                <div ref={(el) => (QRCodeCardRefs.current[index] = el)}>
-                  <QRCodeCanvas value={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} size={150} />
-                </div>
+                <QRCodeCanvas
+                  value={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`}
+                  size={150}
+                  ref={(el) => (QRCodeCanvasRefs.current[index + 1] = el)}
+                />
                 <QRCodeDownloadButton onClick={() => downloadQrCode(index + 1)}>다운로드</QRCodeDownloadButton>
               </QRCodeCard>
             ))}

--- a/src/pages/admin/order/AdminTableCount.tsx
+++ b/src/pages/admin/order/AdminTableCount.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import AppContainer from '@components/common/container/AppContainer';
 import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
@@ -73,6 +73,7 @@ function AdminTableCount() {
   const { fetchWorkspace, updateWorkspaceTableCount } = useAdminWorkspace();
   const setAdminWorkspace = useSetRecoilState(adminWorkspaceAtom);
   const workspace = useRecoilValue(adminWorkspaceAtom);
+  const QRCodeCardRefs = useRef<{ [key: number]: HTMLDivElement | null }>({});
 
   const [debouncedId, setDebouncedId] = useState<NodeJS.Timeout>();
   const baseUrl = `${location.protocol}//${location.host}`;
@@ -92,7 +93,16 @@ function AdminTableCount() {
   };
 
   const downloadQrCode = (tableNo: number) => {
-    const canvas = document.getElementById(`qrcode-${tableNo}`) as HTMLCanvasElement;
+    const qrDiv = QRCodeCardRefs.current[tableNo];
+    if (!qrDiv) {
+      return;
+    }
+
+    const canvas = qrDiv.querySelector('canvas') as HTMLCanvasElement;
+    if (!canvas) {
+      return;
+    }
+
     const link = document.createElement('a');
     link.download = `${tableNo}번 테이블 QR코드.png`;
     link.href = canvas.toDataURL('image/png');
@@ -127,14 +137,10 @@ function AdminTableCount() {
                 <TableLink href={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} target={'_blank'}>
                   {index + 1}번 테이블
                 </TableLink>
-                <QRCodeCanvas value={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} size={150} id={`qrcode-${index + 1}`} />
-                <QRCodeDownloadButton
-                  onClick={() => {
-                    downloadQrCode(index + 1);
-                  }}
-                >
-                  다운로드
-                </QRCodeDownloadButton>
+                <div ref={(el) => (QRCodeCardRefs.current[index] = el)}>
+                  <QRCodeCanvas value={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} size={150} />
+                </div>
+                <QRCodeDownloadButton onClick={() => downloadQrCode(index + 1)}>다운로드</QRCodeDownloadButton>
               </QRCodeCard>
             ))}
           </QRCodeContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7859,10 +7859,10 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
-qrcode.react@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-3.1.0.tgz#5c91ddc0340f768316fbdb8fff2765134c2aecd8"
-  integrity sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==
+qrcode.react@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-4.1.0.tgz#ff15dc9edb135f735bb303a8356938c1e8dcc4c8"
+  integrity sha512-uqXVIIVD/IPgWLYxbOczCNAQw80XCM/LulYDADF+g2xDsPj5OoRwSWtIS4jGyp295wyjKstfG1qIv/I2/rNWpQ==
 
 qs@6.11.0:
   version "6.11.0"


### PR DESCRIPTION
## 📚 개요

- AdminTableCount에서 QRCodeCanvas DOM 접근 방식을 useRef로 변경하려 시도했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

### 기존코드
```js
const canvas = document.getElementById(`qrcode-${tableNo}`) as HTMLCanvasElement;
```

### 변경된 코드
```js
const QRCodeCardRefs = useRef<{ [key: number]: HTMLDivElement | null }>({});

// . . . . .

const qrDiv = QRCodeCardRefs.current[tableNo];
const canvas = qrDiv.querySelector('canvas') as HTMLCanvasElement;

// . . . . .

 <div ref={(el) => (QRCodeCardRefs.current[index] = el)}>
    <QRCodeCanvas value={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} size={150} />
 </div>
```

## 의논하고 싶은 점
원래는 다음과 같이 QRCodeCanvas에 직접적으로 ref를 넘겨주려 했는데 QRCodeCanvas에서 ref를 prop으로 받을 수 없게 선언되어 있었습니다.
```js
    <QRCodeCanvas . . . ref={(el) => (QRCodeCardRefs.current[index] = el)} />
```

이와 관련하여 찾아보니 [can't get the ref](https://github.com/zpao/qrcode.react/issues/140)와 같은 이슈가 있었고, 최근 배포된 version 4에서는 해결된 것으로 보입니다. 그러나 현재 저희가 사용중인 버젼은 version 3이기에 ref를 넘길 수 없는 것 같습니다. 

그리하여 qrcode.react의 version을 update하고 계획했던 대로 QRCodeCanvas에 ref를 넘겨주어 DOM에 접근하도록 변경하는게 어떤지 의논하고 싶습니다!