### PR TITLE
FEAT - Pagination 부분 recoil 대체

### DIFF
--- a/src/components/super-admin/SuperAdminSearchContents.tsx
+++ b/src/components/super-admin/SuperAdminSearchContents.tsx
@@ -20,13 +20,13 @@ interface ContentsProps {
 }
 
 function SuperAdminSearchContents({ contents, target, ContentComponent }: ContentsProps) {
-  if (contents?.empty) {
+  if (contents.empty) {
     return <EmptyLabel className={'empty-label'}>{`찾고자 하는 ${target} 이/가 존재하지 않습니다.`}</EmptyLabel>;
   }
 
   return (
     <>
-      {contents?.content.map((item, index) => (
+      {contents.content.map((item, index) => (
         <div key={item.id}>
           <ContentComponent {...item} />
           {index < contents.content.length - 1 && <HorizontalLine />}

--- a/src/components/super-admin/SuperAdminSearchContents.tsx
+++ b/src/components/super-admin/SuperAdminSearchContents.tsx
@@ -14,7 +14,7 @@ const EmptyLabel = styled.div`
 `;
 
 interface ContentsProps {
-  contents: PaginationResponse<any> | null;
+  contents: PaginationResponse<any>;
   target: string;
   ContentComponent: React.ElementType;
 }

--- a/src/components/super-admin/SuperAdminSearchContents.tsx
+++ b/src/components/super-admin/SuperAdminSearchContents.tsx
@@ -14,19 +14,19 @@ const EmptyLabel = styled.div`
 `;
 
 interface ContentsProps {
-  contents: PaginationResponse<any>;
+  contents: PaginationResponse<any> | null;
   target: string;
   ContentComponent: React.ElementType;
 }
 
 function SuperAdminSearchContents({ contents, target, ContentComponent }: ContentsProps) {
-  if (contents.empty) {
+  if (contents?.empty) {
     return <EmptyLabel className={'empty-label'}>{`찾고자 하는 ${target} 이/가 존재하지 않습니다.`}</EmptyLabel>;
   }
 
   return (
     <>
-      {contents.content.map((item, index) => (
+      {contents?.content.map((item, index) => (
         <div key={item.id}>
           <ContentComponent {...item} />
           {index < contents.content.length - 1 && <HorizontalLine />}

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -41,7 +41,7 @@ interface SuperAdminSearchBarProps extends React.InputHTMLAttributes<HTMLInputEl
 const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProps>((props, ref) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
 
-  const fetchContentsByName = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const fetchContentsByName = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.key === 'Enter' && ref && typeof ref !== 'function')) return;
 
     props.fetchContents(0, 6, ref.current?.value);

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -36,17 +36,16 @@ const SearchBarContainer = styled.div`
   }
 `;
 interface SuperAdminSearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  fetchContents: (page: number, size: number, name: string | undefined) => Promise<PaginationResponse<any> | null>;
-  setContents: (content: PaginationResponse<any> | null) => void;
+  fetchContents: (page: number, size: number, name: string | undefined) => Promise<void>;
 }
 
 const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProps>((props, ref) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
+
   const fetchContentsByName = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.key === 'Enter' && ref && typeof ref !== 'function')) return;
 
-    const response = await props.fetchContents(0, 6, ref.current?.value);
-    props.setContents(response);
+    props.fetchContents(0, 6, ref.current?.value);
   };
 
   return (

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -1,3 +1,4 @@
+import { PaginationResponse } from '@@types/index';
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
 import ActivatedSearchSvg from '@resources/svg/ActivatedSearchSvg';
@@ -35,16 +36,17 @@ const SearchBarContainer = styled.div`
   }
 `;
 interface SuperAdminSearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  fetchContents: (page: number, size: number, name: string | undefined) => void;
+  fetchContents: (page: number, size: number, name: string | undefined) => Promise<PaginationResponse<any> | null>;
+  setContents: (content: PaginationResponse<any> | null) => void;
 }
 
 const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProps>((props, ref) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
-
-  const fetchContentsByName = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const fetchContentsByName = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.key === 'Enter' && ref && typeof ref !== 'function')) return;
 
-    props.fetchContents(0, 6, ref.current?.value);
+    const response = await props.fetchContents(0, 6, ref.current?.value);
+    props.setContents(response);
   };
 
   return (

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -1,4 +1,3 @@
-import { PaginationResponse } from '@@types/index';
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
 import ActivatedSearchSvg from '@resources/svg/ActivatedSearchSvg';

--- a/src/hooks/admin/useAdminOrder.tsx
+++ b/src/hooks/admin/useAdminOrder.tsx
@@ -3,6 +3,7 @@ import { Order, OrderStatus, PaginationResponse } from '@@types/index';
 import { useSetRecoilState } from 'recoil';
 import { ordersAtom, tableOrderPaginationResponseAtom } from '@recoils/atoms';
 import { useSearchParams } from 'react-router-dom';
+import { defaultPaginatoinValue } from '@@types/paginationType';
 
 function useAdminOrder(workspaceId: string | undefined) {
   const { adminApi } = useApi();
@@ -64,11 +65,20 @@ function useAdminOrder(workspaceId: string | undefined) {
   const fetchWorkspaceTable = (tableNumber: number, page: number, size: number) => {
     const params = { workspaceId, tableNumber, page, size };
 
-    adminApi.get<PaginationResponse<Order>>('/orders/table', { params }).then((res) => {
-      setTablePaginationResponse(res.data);
-      searchParams.set('page', params.page.toString());
-      setSearchParams(searchParams);
-    });
+    const response = adminApi
+      .get<PaginationResponse<Order>>('/orders/table', { params })
+      .then((res) => {
+        setTablePaginationResponse(res.data);
+        searchParams.set('page', params.page.toString());
+        setSearchParams(searchParams);
+        return res.data;
+      })
+      .catch((error) => {
+        console.log(error);
+        return defaultPaginatoinValue;
+      });
+
+    return response;
   };
 
   return {

--- a/src/hooks/admin/useAdminOrder.tsx
+++ b/src/hooks/admin/useAdminOrder.tsx
@@ -3,7 +3,7 @@ import { Order, OrderStatus, PaginationResponse } from '@@types/index';
 import { useSetRecoilState } from 'recoil';
 import { ordersAtom, tableOrderPaginationResponseAtom } from '@recoils/atoms';
 import { useSearchParams } from 'react-router-dom';
-import { defaultPaginatoinValue } from '@@types/paginationType';
+import { defaultPaginationValue } from '@@types/PaginationType';
 
 function useAdminOrder(workspaceId: string | undefined) {
   const { adminApi } = useApi();
@@ -75,7 +75,7 @@ function useAdminOrder(workspaceId: string | undefined) {
       })
       .catch((error) => {
         console.log(error);
-        return defaultPaginatoinValue;
+        return defaultPaginationValue;
       });
 
     return response;

--- a/src/hooks/super-admin/useSuperAdminUser.tsx
+++ b/src/hooks/super-admin/useSuperAdminUser.tsx
@@ -1,5 +1,5 @@
 import { PaginationResponse, User } from '@@types/index';
-import { defaultPaginatoinValue } from '@@types/paginationType';
+import { defaultPaginationValue } from '@@types/PaginationType';
 import useApi from '@hooks/useApi';
 import { useSearchParams } from 'react-router-dom';
 
@@ -25,7 +25,7 @@ function useSuperAdminUser() {
       })
       .catch((error) => {
         console.error(error);
-        return defaultPaginatoinValue;
+        return defaultPaginationValue;
       });
 
     return response;

--- a/src/hooks/super-admin/useSuperAdminUser.tsx
+++ b/src/hooks/super-admin/useSuperAdminUser.tsx
@@ -1,4 +1,5 @@
 import { PaginationResponse, User } from '@@types/index';
+import { defaultPaginatoinValue } from '@@types/paginationType';
 import useApi from '@hooks/useApi';
 import { useSearchParams } from 'react-router-dom';
 
@@ -24,7 +25,7 @@ function useSuperAdminUser() {
       })
       .catch((error) => {
         console.error(error);
-        return null;
+        return defaultPaginatoinValue;
       });
 
     return response;

--- a/src/hooks/super-admin/useSuperAdminUser.tsx
+++ b/src/hooks/super-admin/useSuperAdminUser.tsx
@@ -1,8 +1,6 @@
 import { PaginationResponse, User } from '@@types/index';
 import useApi from '@hooks/useApi';
-import { userPaginationResponseAtom } from '@recoils/atoms';
 import { useSearchParams } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
 
 interface FetchAllUsersParamsType {
   page: number;
@@ -13,19 +11,23 @@ interface FetchAllUsersParamsType {
 function useSuperAdminUser() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
-  const setUserPaginationResponse = useSetRecoilState(userPaginationResponseAtom);
 
   const fetchAllUsers = (page: number, size: number, name?: string) => {
     const params: FetchAllUsersParamsType = { page, size, name };
 
-    superAdminApi
+    const response = superAdminApi
       .get<PaginationResponse<User>>('/users', { params })
       .then((res) => {
-        setUserPaginationResponse(res.data);
         searchParams.set('page', params.page.toString());
         setSearchParams(searchParams);
+        return res.data;
       })
-      .catch((error) => console.error(error));
+      .catch((error) => {
+        console.error(error);
+        return null;
+      });
+
+    return response;
   };
 
   return { fetchAllUsers };

--- a/src/hooks/super-admin/useSuperAdminWorkspace.tsx
+++ b/src/hooks/super-admin/useSuperAdminWorkspace.tsx
@@ -1,8 +1,7 @@
 import { PaginationResponse, Workspace } from '@@types/index';
+import { defaultPaginatoinValue } from '@@types/paginationType';
 import useApi from '@hooks/useApi';
-import { workspacePaginationResponseAtom } from '@recoils/atoms';
 import { useSearchParams } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
 
 interface FetchAllWorkspacesParamsType {
   page: number;
@@ -13,19 +12,23 @@ interface FetchAllWorkspacesParamsType {
 function useSuperAdminWorkspace() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
-  const setUserPaginationResponse = useSetRecoilState(workspacePaginationResponseAtom);
 
   const fetchAllWorkspaces = (page: number, size: number, name?: string) => {
     const params: FetchAllWorkspacesParamsType = { page, size, name };
 
-    superAdminApi
+    const response = superAdminApi
       .get<PaginationResponse<Workspace>>('/workspaces', { params })
       .then((res) => {
-        setUserPaginationResponse(res.data);
         searchParams.set('page', params.page.toString());
         setSearchParams(searchParams);
+        return res.data;
       })
-      .catch((error) => console.error(error));
+      .catch((error) => {
+        console.error(error);
+        return defaultPaginatoinValue;
+      });
+
+    return response;
   };
 
   return { fetchAllWorkspaces };

--- a/src/hooks/super-admin/useSuperAdminWorkspace.tsx
+++ b/src/hooks/super-admin/useSuperAdminWorkspace.tsx
@@ -1,5 +1,5 @@
 import { PaginationResponse, Workspace } from '@@types/index';
-import { defaultPaginatoinValue } from '@@types/paginationType';
+import { defaultPaginationValue } from '@@types/PaginationType';
 import useApi from '@hooks/useApi';
 import { useSearchParams } from 'react-router-dom';
 
@@ -25,7 +25,7 @@ function useSuperAdminWorkspace() {
       })
       .catch((error) => {
         console.error(error);
-        return defaultPaginatoinValue;
+        return defaultPaginationValue;
       });
 
     return response;

--- a/src/pages/admin/AdminProductAdd.tsx
+++ b/src/pages/admin/AdminProductAdd.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import useAdminProducts from '@hooks/admin/useAdminProducts';
 import { useRecoilValue } from 'recoil';
 import { categoriesAtom } from '@recoils/atoms';
-import { ProductActionType, ProductStateType } from '@@types/productTypes';
+import { ProductActionType, ProductStateType } from '@@types/ProductTypes';
 import SelectWithLabel from '@components/common/select/SelectWithLabelProps';
 import AppImageInput from '@components/common/input/AppImageInput';
 import AppContainer from '@components/common/container/AppContainer';

--- a/src/pages/admin/AdminProductEdit.tsx
+++ b/src/pages/admin/AdminProductEdit.tsx
@@ -6,7 +6,7 @@ import { categoriesAtom } from '@recoils/atoms';
 import React, { ChangeEvent, useEffect, useReducer } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { initState, ProductActionType, ProductEdit, ProductStateType } from '@@types/productTypes';
+import { initState, ProductActionType, ProductEdit, ProductStateType } from '@@types/ProductTypes';
 import SelectWithLabel from '@components/common/select/SelectWithLabelProps';
 import AppImageInput from '@components/common/input/AppImageInput';
 import useConfirm from '@hooks/useConfirm';

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -9,6 +9,7 @@ import OrderTableHistoryContent from '@components/user/order/OrderTableHistoryCo
 import { Color } from '@resources/colors';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import { Order, PaginationResponse } from '@@types/index';
+import { defaultPaginationValue } from '@@types/PaginationType';
 
 const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
   margin-top: 20px;
@@ -32,7 +33,7 @@ const EmptyLabel = styled.div`
 
 function AdminOrderTableHistory() {
   const { workspaceId, tableNumber } = useParams<{ workspaceId: string; tableNumber: string }>();
-  const [tableOrders, setTableOrders] = useState<PaginationResponse<Order> | null>(null);
+  const [tableOrders, setTableOrders] = useState<PaginationResponse<Order>>(defaultPaginationValue);
   const { replaceLastPath } = useCustomNavigate();
   const { fetchWorkspaceTable } = useAdminOrder(workspaceId);
   const [selectedOrderId, setSelectedOrderId] = useState<number | null>(null);

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -48,12 +48,7 @@ function AdminOrderTableHistory() {
   };
 
   useEffect(() => {
-    const workspaceTableResponse = async () => {
-      const response = await fetchWorkspaceTable(Number(tableNumber), 0, pageSize);
-      setTableOrders(response);
-    };
-
-    workspaceTableResponse();
+    fetchAndSetWorkspaceTable(Number(tableNumber), 0, pageSize);
   }, []);
 
   return (

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -38,13 +38,13 @@ function AdminOrderTableHistory() {
   const { fetchWorkspaceTable } = useAdminOrder(workspaceId);
   const [selectedOrderId, setSelectedOrderId] = useState<number | null>(null);
 
-  const isEmptyWorkspaces = tableOrders?.empty ?? true;
+  const isEmptyWorkspaces = tableOrders.empty;
   const emptyMessage = '찾고자 하는 주문이 존재하지 않습니다.';
 
   const pageSize = 6;
 
-  const fetchAndSetWorkspaceTable = async (tableNum: number, page: number, size: number) => {
-    const workspaceTableResponse = await fetchWorkspaceTable(Number(tableNum), page, size);
+  const fetchAndSetWorkspaceTable = async (tableNo: number, page: number, size: number) => {
+    const workspaceTableResponse = await fetchWorkspaceTable(tableNo, page, size);
     setTableOrders(workspaceTableResponse);
   };
 
@@ -62,7 +62,7 @@ function AdminOrderTableHistory() {
     >
       <>
         <ContentContainer justifyCenter={isEmptyWorkspaces} className={'content-container'}>
-          {tableOrders?.content.map((item, index) => (
+          {tableOrders.content.map((item, index) => (
             <div key={item.id}>
               <OrderTableHistoryContent {...item} isShowDetail={item.id === selectedOrderId} setSelectedOrderId={setSelectedOrderId} />
               {index < tableOrders.content.length - 1 && <HorizontalLine />}
@@ -72,7 +72,7 @@ function AdminOrderTableHistory() {
           {isEmptyWorkspaces && <EmptyLabel className={'empty-label'}>{emptyMessage}</EmptyLabel>}
 
           <Pagination
-            totalPageCount={tableOrders?.totalPages || 0}
+            totalPageCount={tableOrders.totalPages}
             paginateFunction={(page: number) => {
               fetchAndSetWorkspaceTable(Number(tableNumber), page, pageSize);
             }}

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -23,7 +23,7 @@ function SuperAdminUser() {
   const pageSize = 6;
   const navigate = useNavigate();
   const [users, setUsers] = useState<PaginationResponse<User> | null>(null);
-  const userInputRef = useRef<HTMLInputElement | null>(null);
+  const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllUsers } = useSuperAdminUser();
 
   const isEmptyUsers = users?.empty ?? true;
@@ -37,6 +37,11 @@ function SuperAdminUser() {
     userResponse();
   }, []);
 
+  const fetchAndSetUsers = async (page: number, size: number, name: string | undefined) => {
+    const userResponse = await fetchAllUsers(page, size, name);
+    setUsers(userResponse);
+  };
+
   return (
     <AppContainer
       useFlex={colFlex({ justify: 'center' })}
@@ -46,7 +51,7 @@ function SuperAdminUser() {
       titleNavBarProps={{ title: '전체 유저 관리', onLeftArrowClick: () => navigate('/super-admin/manage') }}
     >
       <>
-        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAllUsers} setContents={setUsers} />
+        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAndSetUsers} />
         <ContentContainer justifyCenter={isEmptyUsers} className={'content-container'}>
           <SuperAdminSearchContents contents={users} target={'유저'} ContentComponent={SuperAdminUserContent} />
         </ContentContainer>

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -58,7 +58,7 @@ function SuperAdminUser() {
         <Pagination
           totalPageCount={users?.totalPages || 0}
           paginateFunction={(page: number) => {
-            fetchAllUsers(page, pageSize, userInputRef.current?.value);
+            fetchAndSetUsers(page, pageSize, userInputRef.current?.value);
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -28,19 +28,14 @@ function SuperAdminUser() {
 
   const isEmptyUsers = users?.empty ?? true;
 
-  useEffect(() => {
-    const userResponse = async () => {
-      const response = await fetchAllUsers(0, pageSize);
-      setUsers(response);
-    };
-
-    userResponse();
-  }, []);
-
   const fetchAndSetUsers = async (page: number, size: number, name: string | undefined) => {
     const userResponse = await fetchAllUsers(page, size, name);
     setUsers(userResponse);
   };
+
+  useEffect(() => {
+    fetchAndSetUsers(0, pageSize, '');
+  }, []);
 
   return (
     <AppContainer

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -27,7 +27,7 @@ function SuperAdminUser() {
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllUsers } = useSuperAdminUser();
 
-  const isEmptyUsers = users?.empty ?? true;
+  const isEmptyUsers = users.empty;
 
   const fetchAndSetUsers = async (page: number, size: number, name: string | undefined) => {
     const userResponse = await fetchAllUsers(page, size, name);
@@ -52,7 +52,7 @@ function SuperAdminUser() {
           <SuperAdminSearchContents contents={users} target={'유저'} ContentComponent={SuperAdminUserContent} />
         </ContentContainer>
         <Pagination
-          totalPageCount={users?.totalPages || 0}
+          totalPageCount={users.totalPages}
           paginateFunction={(page: number) => {
             fetchAndSetUsers(page, pageSize, userInputRef.current?.value);
           }}

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -1,15 +1,14 @@
 import SuperAdminSearchBar from '@components/super-admin/workspace/SuperAdminSearchBar';
 import styled from '@emotion/styled';
-import { userPaginationResponseAtom } from '@recoils/atoms';
 import { colFlex } from '@styles/flexStyles';
-import { useEffect, useRef } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useEffect, useRef, useState } from 'react';
 import Pagination from '@components/common/pagination/Pagination';
 import AppContainer from '@components/common/container/AppContainer';
 import useSuperAdminUser from '@hooks/super-admin/useSuperAdminUser';
 import SuperAdminUserContent from '@components/super-admin/user/SuperAdminUserContent';
 import { useNavigate } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
+import { PaginationResponse, User } from '@@types/index';
 
 const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
   height: 550px;
@@ -23,13 +22,19 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminUser() {
   const pageSize = 6;
   const navigate = useNavigate();
+  const [users, setUsers] = useState<PaginationResponse<User> | null>(null);
   const userInputRef = useRef<HTMLInputElement | null>(null);
-  const users = useRecoilValue(userPaginationResponseAtom);
   const { fetchAllUsers } = useSuperAdminUser();
-  const isEmptyUsers = users.empty;
+
+  const isEmptyUsers = users?.empty ?? true;
 
   useEffect(() => {
-    fetchAllUsers(0, pageSize);
+    const userResponse = async () => {
+      const response = await fetchAllUsers(0, pageSize);
+      setUsers(response);
+    };
+
+    userResponse();
   }, []);
 
   return (
@@ -41,12 +46,12 @@ function SuperAdminUser() {
       titleNavBarProps={{ title: '전체 유저 관리', onLeftArrowClick: () => navigate('/super-admin/manage') }}
     >
       <>
-        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAllUsers} />
+        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAllUsers} setContents={setUsers} />
         <ContentContainer justifyCenter={isEmptyUsers} className={'content-container'}>
           <SuperAdminSearchContents contents={users} target={'유저'} ContentComponent={SuperAdminUserContent} />
         </ContentContainer>
         <Pagination
-          totalPageCount={users.totalPages}
+          totalPageCount={users?.totalPages || 0}
           paginateFunction={(page: number) => {
             fetchAllUsers(page, pageSize, userInputRef.current?.value);
           }}

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -9,6 +9,7 @@ import SuperAdminUserContent from '@components/super-admin/user/SuperAdminUserCo
 import { useNavigate } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
 import { PaginationResponse, User } from '@@types/index';
+import { defaultPaginationValue } from '@@types/PaginationType';
 
 const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
   height: 550px;
@@ -22,7 +23,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminUser() {
   const pageSize = 6;
   const navigate = useNavigate();
-  const [users, setUsers] = useState<PaginationResponse<User> | null>(null);
+  const [users, setUsers] = useState<PaginationResponse<User>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllUsers } = useSuperAdminUser();
 

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -27,19 +27,14 @@ function SuperAdminWorkspace() {
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
   const isEmptyWorkspaces = workspaces?.empty ?? true;
 
-  useEffect(() => {
-    const workspaceResponse = async () => {
-      const response = await fetchAllWorkspaces(0, pageSize);
-      setWorkspaces(response);
-    };
-
-    workspaceResponse();
-  }, []);
-
   const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined) => {
     const workspaceResponse = await fetchAllWorkspaces(page, size, name);
     setWorkspaces(workspaceResponse);
   };
+
+  useEffect(() => {
+    fetchAndSetWorkspaces(0, pageSize, '');
+  }, []);
 
   return (
     <AppContainer

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -26,7 +26,7 @@ function SuperAdminWorkspace() {
   const [workspaces, setWorkspaces] = useState<PaginationResponse<Workspace>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement | null>(null);
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
-  const isEmptyWorkspaces = workspaces?.empty ?? true;
+  const isEmptyWorkspaces = workspaces.empty;
 
   const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined) => {
     const workspaceResponse = await fetchAllWorkspaces(page, size, name);
@@ -51,7 +51,7 @@ function SuperAdminWorkspace() {
           <SuperAdminSearchContents contents={workspaces} target={'워크스페이스'} ContentComponent={SuperAdminWorkspaceContent} />
         </ContentContainer>
         <Pagination
-          totalPageCount={workspaces?.totalPages || 0}
+          totalPageCount={workspaces.totalPages}
           paginateFunction={(page: number) => {
             fetchAndSetWorkspaces(page, pageSize, userInputRef.current?.value);
           }}

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
 import { PaginationResponse, Workspace } from '@@types/index';
 import { useEffect, useRef, useState } from 'react';
+import { defaultPaginationValue } from '@@types/PaginationType';
 
 const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
   height: 550px;
@@ -22,7 +23,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminWorkspace() {
   const pageSize = 6;
   const navigate = useNavigate();
-  const [workspaces, setWorkspaces] = useState<PaginationResponse<Workspace> | null>(null);
+  const [workspaces, setWorkspaces] = useState<PaginationResponse<Workspace>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement | null>(null);
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
   const isEmptyWorkspaces = workspaces?.empty ?? true;

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -2,14 +2,13 @@ import AppContainer from '@components/common/container/AppContainer';
 import Pagination from '@components/common/pagination/Pagination';
 import SuperAdminSearchBar from '@components/super-admin/workspace/SuperAdminSearchBar';
 import styled from '@emotion/styled';
-import { workspacePaginationResponseAtom } from '@recoils/atoms';
-import { useEffect, useRef } from 'react';
-import { useRecoilValue } from 'recoil';
 import useSuperAdminWorkspace from '@hooks/super-admin/useSuperAdminWorkspace';
 import { colFlex } from '@styles/flexStyles';
 import SuperAdminWorkspaceContent from '@components/super-admin/workspace/SuperAdminWorkspaceContent';
 import { useNavigate } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
+import { PaginationResponse, Workspace } from '@@types/index';
+import { useEffect, useRef, useState } from 'react';
 
 const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
   height: 550px;
@@ -23,14 +22,24 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminWorkspace() {
   const pageSize = 6;
   const navigate = useNavigate();
+  const [workspaces, setWorkspaces] = useState<PaginationResponse<Workspace> | null>(null);
   const userInputRef = useRef<HTMLInputElement | null>(null);
-  const workspaces = useRecoilValue(workspacePaginationResponseAtom);
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
-  const isEmptyWorkspaces = workspaces.empty;
+  const isEmptyWorkspaces = workspaces?.empty ?? true;
 
   useEffect(() => {
-    fetchAllWorkspaces(0, pageSize);
+    const workspaceResponse = async () => {
+      const response = await fetchAllWorkspaces(0, pageSize);
+      setWorkspaces(response);
+    };
+
+    workspaceResponse();
   }, []);
+
+  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined) => {
+    const workspaceResponse = await fetchAllWorkspaces(page, size, name);
+    setWorkspaces(workspaceResponse);
+  };
 
   return (
     <AppContainer
@@ -41,12 +50,12 @@ function SuperAdminWorkspace() {
       titleNavBarProps={{ title: '전체 워크스페이스 관리', onLeftArrowClick: () => navigate('/super-admin/manage') }}
     >
       <>
-        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAllWorkspaces} />
+        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAndSetWorkspaces} />
         <ContentContainer justifyCenter={isEmptyWorkspaces} className={'content-container'}>
           <SuperAdminSearchContents contents={workspaces} target={'워크스페이스'} ContentComponent={SuperAdminWorkspaceContent} />
         </ContentContainer>
         <Pagination
-          totalPageCount={workspaces.totalPages}
+          totalPageCount={workspaces?.totalPages || 0}
           paginateFunction={(page: number) => {
             fetchAllWorkspaces(page, pageSize, userInputRef.current?.value);
           }}

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -57,7 +57,7 @@ function SuperAdminWorkspace() {
         <Pagination
           totalPageCount={workspaces?.totalPages || 0}
           paginateFunction={(page: number) => {
-            fetchAllWorkspaces(page, pageSize, userInputRef.current?.value);
+            fetchAndSetWorkspaces(page, pageSize, userInputRef.current?.value);
           }}
         />
       </>

--- a/src/recoils/atoms.ts
+++ b/src/recoils/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
 import { Order, OrderProductBase, OrderStatus, PaginationResponse, Product, ProductCategory, User, UserRole, Workspace } from '@@types/index';
+import { defaultPaginatoinValue } from '@@types/paginationType';
 
 export const ordersAtom = atom<Order[]>({
   key: 'ordersAtom',
@@ -108,96 +109,15 @@ export const isLoadingAtom = atom<boolean>({
 
 export const workspacePaginationResponseAtom = atom<PaginationResponse<Workspace>>({
   key: 'workspacePaginationResponseAtom',
-  default: {
-    content: [],
-    pageable: {
-      pageNumber: 0,
-      pageSize: 6,
-      sort: {
-        sorted: false,
-        empty: true,
-        unsorted: true,
-      },
-      offset: 0,
-      paged: true,
-      unpaged: false,
-    },
-    totalPages: 0,
-    totalElements: 0,
-    last: false,
-    number: 0,
-    size: 6,
-    numberOfElements: 0,
-    sort: {
-      sorted: false,
-      empty: true,
-      unsorted: true,
-    },
-    first: true,
-    empty: true,
-  },
+  default: defaultPaginatoinValue,
 });
 
 export const userPaginationResponseAtom = atom<PaginationResponse<User>>({
   key: 'userPaginationResponseAtom',
-  default: {
-    content: [],
-    pageable: {
-      pageNumber: 0,
-      pageSize: 6,
-      sort: {
-        sorted: false,
-        empty: true,
-        unsorted: true,
-      },
-      offset: 0,
-      paged: true,
-      unpaged: false,
-    },
-    totalPages: 0,
-    totalElements: 0,
-    last: false,
-    number: 0,
-    size: 6,
-    numberOfElements: 0,
-    sort: {
-      sorted: false,
-      empty: true,
-      unsorted: true,
-    },
-    first: true,
-    empty: true,
-  },
+  default: defaultPaginatoinValue,
 });
 
 export const tableOrderPaginationResponseAtom = atom<PaginationResponse<Order>>({
   key: 'tableOrderPaginationResponseAtom',
-  default: {
-    content: [],
-    pageable: {
-      pageNumber: 0,
-      pageSize: 6,
-      sort: {
-        sorted: false,
-        empty: true,
-        unsorted: true,
-      },
-      offset: 0,
-      paged: true,
-      unpaged: false,
-    },
-    totalPages: 0,
-    totalElements: 0,
-    last: false,
-    number: 0,
-    size: 6,
-    numberOfElements: 0,
-    sort: {
-      sorted: false,
-      empty: true,
-      unsorted: true,
-    },
-    first: true,
-    empty: true,
-  },
+  default: defaultPaginatoinValue,
 });

--- a/src/recoils/atoms.ts
+++ b/src/recoils/atoms.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 import { Order, OrderProductBase, OrderStatus, PaginationResponse, Product, ProductCategory, User, UserRole, Workspace } from '@@types/index';
-import { defaultPaginatoinValue } from '@@types/paginationType';
+import { defaultPaginationValue } from '@@types/PaginationType';
 
 export const ordersAtom = atom<Order[]>({
   key: 'ordersAtom',
@@ -109,15 +109,15 @@ export const isLoadingAtom = atom<boolean>({
 
 export const workspacePaginationResponseAtom = atom<PaginationResponse<Workspace>>({
   key: 'workspacePaginationResponseAtom',
-  default: defaultPaginatoinValue,
+  default: defaultPaginationValue,
 });
 
 export const userPaginationResponseAtom = atom<PaginationResponse<User>>({
   key: 'userPaginationResponseAtom',
-  default: defaultPaginatoinValue,
+  default: defaultPaginationValue,
 });
 
 export const tableOrderPaginationResponseAtom = atom<PaginationResponse<Order>>({
   key: 'tableOrderPaginationResponseAtom',
-  default: defaultPaginatoinValue,
+  default: defaultPaginationValue,
 });

--- a/src/types/paginationType.ts
+++ b/src/types/paginationType.ts
@@ -1,6 +1,6 @@
 import { PaginationResponse } from '.';
 
-export const defaultPaginatoinValue: PaginationResponse<any> = {
+export const defaultPaginationValue: PaginationResponse<any> = {
   content: [],
   pageable: {
     pageNumber: 0,

--- a/src/types/paginationType.ts
+++ b/src/types/paginationType.ts
@@ -1,0 +1,30 @@
+import { PaginationResponse } from '.';
+
+export const defaultPaginatoinValue: PaginationResponse<any> = {
+  content: [],
+  pageable: {
+    pageNumber: 0,
+    pageSize: 6,
+    sort: {
+      sorted: false,
+      empty: true,
+      unsorted: true,
+    },
+    offset: 0,
+    paged: true,
+    unpaged: false,
+  },
+  totalPages: 0,
+  totalElements: 0,
+  last: false,
+  number: 0,
+  size: 6,
+  numberOfElements: 0,
+  sort: {
+    sorted: false,
+    empty: true,
+    unsorted: true,
+  },
+  first: true,
+  empty: true,
+};


### PR DESCRIPTION
## 📚 개요

- Pagination 부분에서 recoil 대신 useState로 사용하려 했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

## 시도

```jsx
  const fetchAllUsers = (page: number, size: number, name?: string) => {
    const params: FetchAllUsersParamsType = { page, size, name };

    const response = superAdminApi
      .get<PaginationResponse<User>>('/users', { params })
      .then((res) => {
        searchParams.set('page', params.page.toString());
        setSearchParams(searchParams);
        return res.data;
      })
      .catch((error) => {
        console.error(error);
        return null;
      });

    return response;
  };
```

`fetchAllUsers` 함수로 위와 같은 형태로 받아온 데이터(`res.data`)를 반환하고, 

```jsx
  const [users, setUsers] = useState<PaginationResponse<User> | null>(null);

  useEffect(() => {
    const userResponse = async () => {
      const response = await fetchAllUsers(0, pageSize);
      setUsers(response);
    };

    userResponse();
  }, []);
```

사용하는 곳에서 `useState`로 관리하려 했다. 사실 여기까지는 문제가 없다. 

그러나 문제가 생기는 곳은 바로 SearchBar이다.

```jsx
<SuperAdminSearchBar fetchContents={fetchAllUsers} />
```

우리는 현재 SearchBar에 컨텐츠를 fetch하는 함수를 넘겨주고 있다.

이제 SearchBar를 들여다 보자.

```tsx
const [paginationData, setPaginationData] = useState<PaginationResponse<any> | null>(null);

const fetchContentsByName = async (e: React.KeyboardEvent<HTMLInputElement>) => {
  if (!(e.key === 'Enter' && ref && typeof ref !== 'function')) return;

  const response = await props.fetchContents(0, 6, ref.current?.value);
  setPaginationData(response);
};

 // 'paginationData' is assigned a value but never used
```

여기서도 useState를 활용하여 데이터를 받아오는 것 자체는 **가능**하다. 그러나, 받아온 데이터를 자매 컴포넌트인 SuperAdminSearchContents로 넘겨줘야 한다. 하려면 할 수 있겠지만 이렇게 사용할 바엔 기존 코드처럼 recoil을 이용하는게 더 낫지 않을까? 라는 생각이 들었다. 

즉, 단순히 초기 pagination 데이터를 fetch하여 보여주는건 가능, 그러나 검색시 변경된 데이터를 받아오려면 부모컴포넌트(`SuperAdminUser`)에서 자식 컴포넌트(`SuperAdminSearchBar`)에게 prop으로 set함수를 넘겨줘야 한다.  이렇게 되면 결국 recoil을 안쓸 이유가 없지 않을까?


---

## 해결방법
```js
  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined) => {
    const workspaceResponse = await fetchAllWorkspaces(page, size, name);
    setWorkspaces(workspaceResponse);
  };
```
- 위와 같이 fetch해온 값을 set하는 함수로 기존에 fetch해오던 함수를 대체했습니다.