### PR TITLE
FIX - pagination 페이지에서 뒤로 가기 클릭 시 쿼리스트링 값에 의해 2번 클릭해야 하는 버그 수정

### DIFF
--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -3,7 +3,7 @@ import { Color } from '@resources/colors';
 import ActivatedSearchSvg from '@resources/svg/ActivatedSearchSvg';
 import DeactivatedSearchSvg from '@resources/svg/DeactivatedSearchSvg';
 import { rowFlex } from '@styles/flexStyles';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 const Input = styled.input`
@@ -41,6 +41,12 @@ function SuperAdminSearchBar() {
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [searchParams, setSearchParams] = useSearchParams();
 
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.value = searchParams.get('name') || '';
+    }
+  }, [searchParams]);
+
   const fetchContentsByName = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.key === 'Enter' && inputRef && typeof inputRef !== 'function')) return;
 
@@ -53,8 +59,6 @@ function SuperAdminSearchBar() {
     }
 
     setSearchParams(searchParams);
-
-    inputRef.current!.value = '';
   };
 
   return (

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -45,7 +45,7 @@ function SuperAdminSearchBar() {
     if (inputRef.current) {
       inputRef.current.value = searchParams.get('name') || '';
     }
-  }, [searchParams]);
+  }, [searchParams.toString()]);
 
   const fetchContentsByName = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.key === 'Enter' && inputRef && typeof inputRef !== 'function')) return;

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -35,7 +35,7 @@ const SearchBarContainer = styled.div`
   }
 `;
 interface SuperAdminSearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  fetchContents: (page: number, size: number, name: string | undefined) => Promise<void> | void;
+  fetchContents: (page: number, size: number, name: string | undefined, replace: boolean) => Promise<void> | void;
 }
 
 const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProps>((props, ref) => {
@@ -44,7 +44,7 @@ const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProp
   const fetchContentsByName = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.key === 'Enter' && ref && typeof ref !== 'function')) return;
 
-    props.fetchContents(0, 6, ref.current?.value);
+    props.fetchContents(0, 6, ref.current?.value, false);
   };
 
   return (

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -3,7 +3,7 @@ import { Color } from '@resources/colors';
 import ActivatedSearchSvg from '@resources/svg/ActivatedSearchSvg';
 import DeactivatedSearchSvg from '@resources/svg/DeactivatedSearchSvg';
 import { rowFlex } from '@styles/flexStyles';
-import React, { forwardRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 const Input = styled.input`
@@ -35,33 +35,33 @@ const SearchBarContainer = styled.div`
     border-bottom: 0.5px solid black;
   }
 `;
-interface SuperAdminSearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  fetchContents: (page: number, size: number, name: string | undefined) => Promise<void> | void;
-}
 
-const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProps>((props, ref) => {
+function SuperAdminSearchBar() {
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [searchParams, setSearchParams] = useSearchParams();
 
   const fetchContentsByName = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!(e.key === 'Enter' && ref && typeof ref !== 'function')) return;
+    if (!(e.key === 'Enter' && inputRef && typeof inputRef !== 'function')) return;
 
-    if (ref.current?.value === '') {
+    searchParams.set('page', '0');
+
+    if (inputRef.current?.value === '') {
       searchParams.delete('name');
     } else {
-      searchParams.set('page', '0');
-      searchParams.set('name', String(ref.current?.value));
+      searchParams.set('name', String(inputRef.current?.value));
     }
 
-    setSearchParams(searchParams, { replace: true });
+    setSearchParams(searchParams);
+
+    inputRef.current!.value = '';
   };
 
   return (
     <SearchBarContainer className={'search-bar-container'}>
       {isFocused ? <ActivatedSearchSvg /> : <DeactivatedSearchSvg />}
       <Input
-        {...props}
-        ref={ref}
+        ref={inputRef}
         type="text"
         placeholder={`이름을 입력해주세요`}
         onKeyDown={fetchContentsByName}
@@ -70,6 +70,6 @@ const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProp
       />
     </SearchBarContainer>
   );
-});
+}
 
 export default SuperAdminSearchBar;

--- a/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
+++ b/src/components/super-admin/workspace/SuperAdminSearchBar.tsx
@@ -4,6 +4,7 @@ import ActivatedSearchSvg from '@resources/svg/ActivatedSearchSvg';
 import DeactivatedSearchSvg from '@resources/svg/DeactivatedSearchSvg';
 import { rowFlex } from '@styles/flexStyles';
 import React, { forwardRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 const Input = styled.input`
   width: 100%;
@@ -35,16 +36,24 @@ const SearchBarContainer = styled.div`
   }
 `;
 interface SuperAdminSearchBarProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  fetchContents: (page: number, size: number, name: string | undefined, replace: boolean) => Promise<void> | void;
+  fetchContents: (page: number, size: number, name: string | undefined) => Promise<void> | void;
 }
 
 const SuperAdminSearchBar = forwardRef<HTMLInputElement, SuperAdminSearchBarProps>((props, ref) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const fetchContentsByName = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!(e.key === 'Enter' && ref && typeof ref !== 'function')) return;
 
-    props.fetchContents(0, 6, ref.current?.value, false);
+    if (ref.current?.value === '') {
+      searchParams.delete('name');
+    } else {
+      searchParams.set('page', '0');
+      searchParams.set('name', String(ref.current?.value));
+    }
+
+    setSearchParams(searchParams, { replace: true });
   };
 
   return (

--- a/src/hooks/admin/useAdminOrder.tsx
+++ b/src/hooks/admin/useAdminOrder.tsx
@@ -2,14 +2,12 @@ import useApi from '@hooks/useApi';
 import { Order, OrderStatus, PaginationResponse } from '@@types/index';
 import { useSetRecoilState } from 'recoil';
 import { ordersAtom, tableOrderPaginationResponseAtom } from '@recoils/atoms';
-import { useSearchParams } from 'react-router-dom';
 import { defaultPaginationValue } from '@@types/PaginationType';
 
 function useAdminOrder(workspaceId: string | undefined) {
   const { adminApi } = useApi();
   const setOrders = useSetRecoilState(ordersAtom);
   const setTablePaginationResponse = useSetRecoilState(tableOrderPaginationResponseAtom);
-  const [searchParams, setSearchParams] = useSearchParams();
 
   const fetchAllOrders = () => {
     adminApi.get<Order[]>('/orders', { params: { workspaceId } }).then((response) => {
@@ -62,15 +60,13 @@ function useAdminOrder(workspaceId: string | undefined) {
     });
   };
 
-  const fetchWorkspaceTable = (tableNumber: number, page: number, size: number, replace: boolean) => {
+  const fetchWorkspaceTable = (tableNumber: number, page: number, size: number) => {
     const params = { workspaceId, tableNumber, page, size };
 
     const response = adminApi
       .get<PaginationResponse<Order>>('/orders/table', { params })
       .then((res) => {
         setTablePaginationResponse(res.data);
-        searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/hooks/admin/useAdminOrder.tsx
+++ b/src/hooks/admin/useAdminOrder.tsx
@@ -62,7 +62,7 @@ function useAdminOrder(workspaceId: string | undefined) {
     });
   };
 
-  const fetchWorkspaceTable = (tableNumber: number, page: number, size: number) => {
+  const fetchWorkspaceTable = (tableNumber: number, page: number, size: number, replace: boolean) => {
     const params = { workspaceId, tableNumber, page, size };
 
     const response = adminApi
@@ -70,7 +70,7 @@ function useAdminOrder(workspaceId: string | undefined) {
       .then((res) => {
         setTablePaginationResponse(res.data);
         searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams);
+        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/hooks/super-admin/useSuperAdminEmail.tsx
+++ b/src/hooks/super-admin/useSuperAdminEmail.tsx
@@ -1,7 +1,6 @@
 import { PaginationResponse, EmailDomain } from '@@types/index';
 import useApi from '@hooks/useApi';
 import { emailDomainPaginationResponseAtom } from '@recoils/atoms';
-import { useSearchParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 interface FetchAllEmailDomainParamsType {
@@ -17,17 +16,14 @@ interface AddEmailDomainParamsType {
 
 function useSuperAdminEmail() {
   const setEmailPaginationResponse = useSetRecoilState(emailDomainPaginationResponseAtom);
-  const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
 
-  const fetchAllEmailDomain = (page: number, size: number, name?: string, replace?: boolean) => {
+  const fetchAllEmailDomain = (page: number, size: number, name?: string) => {
     const params: FetchAllEmailDomainParamsType = { page, size, name };
 
     superAdminApi
       .get<PaginationResponse<EmailDomain>>('/email-domains', { params })
       .then((res) => {
-        searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams, { replace });
         setEmailPaginationResponse(res.data);
       })
       .catch((error) => {

--- a/src/hooks/super-admin/useSuperAdminEmail.tsx
+++ b/src/hooks/super-admin/useSuperAdminEmail.tsx
@@ -20,14 +20,14 @@ function useSuperAdminEmail() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
 
-  const fetchAllEmailDomain = (page: number, size: number, name?: string) => {
+  const fetchAllEmailDomain = (page: number, size: number, name?: string, replace?: boolean) => {
     const params: FetchAllEmailDomainParamsType = { page, size, name };
 
     superAdminApi
       .get<PaginationResponse<EmailDomain>>('/email-domains', { params })
       .then((res) => {
         searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams);
+        setSearchParams(searchParams, { replace });
         setEmailPaginationResponse(res.data);
       })
       .catch((error) => {

--- a/src/hooks/super-admin/useSuperAdminUser.tsx
+++ b/src/hooks/super-admin/useSuperAdminUser.tsx
@@ -1,7 +1,6 @@
 import { PaginationResponse, User } from '@@types/index';
 import { defaultPaginationValue } from '@@types/PaginationType';
 import useApi from '@hooks/useApi';
-import { useSearchParams } from 'react-router-dom';
 
 interface FetchAllUsersParamsType {
   page: number;
@@ -10,17 +9,14 @@ interface FetchAllUsersParamsType {
 }
 
 function useSuperAdminUser() {
-  const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
 
-  const fetchAllUsers = (page: number, size: number, name?: string, replace?: boolean) => {
+  const fetchAllUsers = (page: number, size: number, name?: string) => {
     const params: FetchAllUsersParamsType = { page, size, name };
 
     const response = superAdminApi
       .get<PaginationResponse<User>>('/users', { params })
       .then((res) => {
-        searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/hooks/super-admin/useSuperAdminUser.tsx
+++ b/src/hooks/super-admin/useSuperAdminUser.tsx
@@ -13,14 +13,14 @@ function useSuperAdminUser() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
 
-  const fetchAllUsers = (page: number, size: number, name?: string) => {
+  const fetchAllUsers = (page: number, size: number, name?: string, replace?: boolean) => {
     const params: FetchAllUsersParamsType = { page, size, name };
 
     const response = superAdminApi
       .get<PaginationResponse<User>>('/users', { params })
       .then((res) => {
         searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams);
+        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/hooks/super-admin/useSuperAdminWorkspace.tsx
+++ b/src/hooks/super-admin/useSuperAdminWorkspace.tsx
@@ -13,14 +13,14 @@ function useSuperAdminWorkspace() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
 
-  const fetchAllWorkspaces = (page: number, size: number, name?: string) => {
+  const fetchAllWorkspaces = (page: number, size: number, name?: string, replace?: boolean) => {
     const params: FetchAllWorkspacesParamsType = { page, size, name };
 
     const response = superAdminApi
       .get<PaginationResponse<Workspace>>('/workspaces', { params })
       .then((res) => {
         searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams);
+        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/hooks/super-admin/useSuperAdminWorkspace.tsx
+++ b/src/hooks/super-admin/useSuperAdminWorkspace.tsx
@@ -1,7 +1,6 @@
 import { PaginationResponse, Workspace } from '@@types/index';
 import { defaultPaginationValue } from '@@types/PaginationType';
 import useApi from '@hooks/useApi';
-import { useSearchParams } from 'react-router-dom';
 
 interface FetchAllWorkspacesParamsType {
   page: number;
@@ -10,17 +9,14 @@ interface FetchAllWorkspacesParamsType {
 }
 
 function useSuperAdminWorkspace() {
-  const [searchParams, setSearchParams] = useSearchParams();
   const { superAdminApi } = useApi();
 
-  const fetchAllWorkspaces = (page: number, size: number, name?: string, replace?: boolean) => {
+  const fetchAllWorkspaces = (page: number, size: number, name?: string) => {
     const params: FetchAllWorkspacesParamsType = { page, size, name };
 
     const response = superAdminApi
       .get<PaginationResponse<Workspace>>('/workspaces', { params })
       .then((res) => {
-        searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/hooks/useCustomNavigate.tsx
+++ b/src/hooks/useCustomNavigate.tsx
@@ -14,7 +14,12 @@ function useCustomNavigate() {
     navigate(url);
   };
 
-  return { appendPath, replaceLastPath };
+  const navigateWithPage = (path: string, additionalParams = {}) => {
+    const params = new URLSearchParams({ page: '0', ...additionalParams });
+    navigate(`${path}?${params.toString()}`);
+  };
+
+  return { appendPath, replaceLastPath, navigateWithPage };
 }
 
 export default useCustomNavigate;

--- a/src/hooks/useCustomNavigate.tsx
+++ b/src/hooks/useCustomNavigate.tsx
@@ -16,7 +16,7 @@ function useCustomNavigate() {
 
   const navigateWithPage = (path: string, additionalParams = {}) => {
     const params = new URLSearchParams({ page: '0', ...additionalParams });
-    navigate(`${path}?${params.toString()}`);
+    navigate({ pathname: path, search: params.toString() });
   };
 
   return { appendPath, replaceLastPath, navigateWithPage };

--- a/src/hooks/user/useEmail.tsx
+++ b/src/hooks/user/useEmail.tsx
@@ -1,7 +1,6 @@
 import { PaginationResponse, EmailDomain } from '@@types/index';
 import { defaultPaginationValue } from '@@types/PaginationType';
 import useApi from '@hooks/useApi';
-import { useSearchParams } from 'react-router-dom';
 
 interface FetchAllEmailDomainParamsType {
   page: number;
@@ -11,16 +10,13 @@ interface FetchAllEmailDomainParamsType {
 
 function useEmail() {
   const { userApi } = useApi();
-  const [searchParams, setSearchParams] = useSearchParams();
 
-  const fetchAllEmailDomain = (page: number, size: number, name?: string, replace?: boolean) => {
+  const fetchAllEmailDomain = (page: number, size: number, name?: string) => {
     const params: FetchAllEmailDomainParamsType = { page, size, name };
 
     const response = userApi
       .get<PaginationResponse<EmailDomain>>('/email-domains', { params })
       .then((res) => {
-        searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/hooks/user/useEmail.tsx
+++ b/src/hooks/user/useEmail.tsx
@@ -13,14 +13,14 @@ function useEmail() {
   const { userApi } = useApi();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const fetchAllEmailDomain = (page: number, size: number, name?: string) => {
+  const fetchAllEmailDomain = (page: number, size: number, name?: string, replace?: boolean) => {
     const params: FetchAllEmailDomainParamsType = { page, size, name };
 
     const response = userApi
       .get<PaginationResponse<EmailDomain>>('/email-domains', { params })
       .then((res) => {
         searchParams.set('page', params.page.toString());
-        setSearchParams(searchParams);
+        setSearchParams(searchParams, { replace });
         return res.data;
       })
       .catch((error) => {

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -53,7 +53,7 @@ function AdminOrderTableHistory() {
     const nowPage = Number(searchParams.get('page'));
 
     fetchAndSetWorkspaceTable(Number(tableNumber), nowPage, pageSize);
-  }, [searchParams]);
+  }, [searchParams.toString()]);
 
   return (
     <AppContainer

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -3,7 +3,7 @@ import Pagination from '@components/common/pagination/Pagination';
 import styled from '@emotion/styled';
 import { colFlex } from '@styles/flexStyles';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import useCustomNavigate from '@hooks/useCustomNavigate';
 import OrderTableHistoryContent from '@components/user/order/OrderTableHistoryCotent';
 import { Color } from '@resources/colors';
@@ -32,6 +32,7 @@ const EmptyLabel = styled.div`
 `;
 
 function AdminOrderTableHistory() {
+  const [searchParams] = useSearchParams();
   const { workspaceId, tableNumber } = useParams<{ workspaceId: string; tableNumber: string }>();
   const [tableOrders, setTableOrders] = useState<PaginationResponse<Order>>(defaultPaginationValue);
   const { replaceLastPath } = useCustomNavigate();
@@ -43,14 +44,16 @@ function AdminOrderTableHistory() {
 
   const pageSize = 6;
 
-  const fetchAndSetWorkspaceTable = async (tableNo: number, page: number, size: number) => {
-    const workspaceTableResponse = await fetchWorkspaceTable(tableNo, page, size);
+  const fetchAndSetWorkspaceTable = async (tableNo: number, page: number, size: number, replace?: boolean) => {
+    const workspaceTableResponse = await fetchWorkspaceTable(tableNo, page, size, replace ?? false);
     setTableOrders(workspaceTableResponse);
   };
 
   useEffect(() => {
-    fetchAndSetWorkspaceTable(Number(tableNumber), 0, pageSize);
-  }, []);
+    const nowPage = Number(searchParams.get('page'));
+
+    fetchAndSetWorkspaceTable(Number(tableNumber), nowPage, pageSize, true);
+  }, [searchParams]);
 
   return (
     <AppContainer

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -44,15 +44,15 @@ function AdminOrderTableHistory() {
 
   const pageSize = 6;
 
-  const fetchAndSetWorkspaceTable = async (tableNo: number, page: number, size: number, replace: boolean = false) => {
-    const workspaceTableResponse = await fetchWorkspaceTable(tableNo, page, size, replace);
+  const fetchAndSetWorkspaceTable = async (tableNo: number, page: number, size: number) => {
+    const workspaceTableResponse = await fetchWorkspaceTable(tableNo, page, size);
     setTableOrders(workspaceTableResponse);
   };
 
   useEffect(() => {
     const nowPage = Number(searchParams.get('page'));
 
-    fetchAndSetWorkspaceTable(Number(tableNumber), nowPage, pageSize, true);
+    fetchAndSetWorkspaceTable(Number(tableNumber), nowPage, pageSize);
   }, [searchParams]);
 
   return (
@@ -78,7 +78,7 @@ function AdminOrderTableHistory() {
             totalPageCount={tableOrders.totalPages}
             paginateFunction={(page: number) => {
               searchParams.set('page', page.toString());
-              setSearchParams(searchParams, { replace: false });
+              setSearchParams(searchParams);
             }}
           />
         </ContentContainer>

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -32,7 +32,7 @@ const EmptyLabel = styled.div`
 `;
 
 function AdminOrderTableHistory() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { workspaceId, tableNumber } = useParams<{ workspaceId: string; tableNumber: string }>();
   const [tableOrders, setTableOrders] = useState<PaginationResponse<Order>>(defaultPaginationValue);
   const { replaceLastPath } = useCustomNavigate();
@@ -77,7 +77,8 @@ function AdminOrderTableHistory() {
           <Pagination
             totalPageCount={tableOrders.totalPages}
             paginateFunction={(page: number) => {
-              fetchAndSetWorkspaceTable(Number(tableNumber), page, pageSize);
+              searchParams.set('page', page.toString());
+              setSearchParams(searchParams, { replace: false });
             }}
           />
         </ContentContainer>

--- a/src/pages/admin/order/AdminOrderTableHistory.tsx
+++ b/src/pages/admin/order/AdminOrderTableHistory.tsx
@@ -44,8 +44,8 @@ function AdminOrderTableHistory() {
 
   const pageSize = 6;
 
-  const fetchAndSetWorkspaceTable = async (tableNo: number, page: number, size: number, replace?: boolean) => {
-    const workspaceTableResponse = await fetchWorkspaceTable(tableNo, page, size, replace ?? false);
+  const fetchAndSetWorkspaceTable = async (tableNo: number, page: number, size: number, replace: boolean = false) => {
+    const workspaceTableResponse = await fetchWorkspaceTable(tableNo, page, size, replace);
     setTableOrders(workspaceTableResponse);
   };
 

--- a/src/pages/super-admin/SuperAdminEmailDomainList.tsx
+++ b/src/pages/super-admin/SuperAdminEmailDomainList.tsx
@@ -35,7 +35,7 @@ function SuperAdminEmailDomainList() {
     const searchValue = searchParams.get('name') || '';
 
     fetchAllEmailDomain(nowPage, pageSize, searchValue);
-  }, [searchParams]);
+  }, [searchParams.toString()]);
 
   return (
     <AppContainer

--- a/src/pages/super-admin/SuperAdminEmailDomainList.tsx
+++ b/src/pages/super-admin/SuperAdminEmailDomainList.tsx
@@ -4,7 +4,7 @@ import { colFlex } from '@styles/flexStyles';
 import { useEffect, useRef } from 'react';
 import Pagination from '@components/common/pagination/Pagination';
 import AppContainer from '@components/common/container/AppContainer';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
 import useSuperAdminEmail from '@hooks/super-admin/useSuperAdminEmail';
 import SuperAdminEmailDomainContent from '@components/super-admin/email/SuperAdminEmailDomainContent';
@@ -24,6 +24,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminEmailDomainList() {
   const pageSize = 6;
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const emailDomain = useRecoilValue(emailDomainPaginationResponseAtom);
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllEmailDomain } = useSuperAdminEmail();
@@ -31,8 +32,11 @@ function SuperAdminEmailDomainList() {
   const isEmptyEmailDomain = emailDomain.empty;
 
   useEffect(() => {
-    fetchAllEmailDomain(0, pageSize);
-  }, []);
+    const nowPage = Number(searchParams.get('page'));
+    const searchValue = userInputRef.current?.value || '';
+
+    fetchAllEmailDomain(nowPage, pageSize, searchValue, true);
+  }, [searchParams]);
 
   return (
     <AppContainer
@@ -54,7 +58,7 @@ function SuperAdminEmailDomainList() {
         <Pagination
           totalPageCount={emailDomain.totalPages}
           paginateFunction={(page: number) => {
-            fetchAllEmailDomain(page, pageSize, userInputRef.current?.value);
+            fetchAllEmailDomain(page, pageSize, userInputRef.current?.value, false);
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminEmailDomainList.tsx
+++ b/src/pages/super-admin/SuperAdminEmailDomainList.tsx
@@ -24,7 +24,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminEmailDomainList() {
   const pageSize = 6;
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const emailDomain = useRecoilValue(emailDomainPaginationResponseAtom);
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllEmailDomain } = useSuperAdminEmail();
@@ -58,7 +58,8 @@ function SuperAdminEmailDomainList() {
         <Pagination
           totalPageCount={emailDomain.totalPages}
           paginateFunction={(page: number) => {
-            fetchAllEmailDomain(page, pageSize, userInputRef.current?.value, false);
+            searchParams.set('page', page.toString());
+            setSearchParams(searchParams, { replace: false });
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminEmailDomainList.tsx
+++ b/src/pages/super-admin/SuperAdminEmailDomainList.tsx
@@ -1,7 +1,7 @@
 import SuperAdminSearchBar from '@components/super-admin/workspace/SuperAdminSearchBar';
 import styled from '@emotion/styled';
 import { colFlex } from '@styles/flexStyles';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import Pagination from '@components/common/pagination/Pagination';
 import AppContainer from '@components/common/container/AppContainer';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -26,14 +26,13 @@ function SuperAdminEmailDomainList() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const emailDomain = useRecoilValue(emailDomainPaginationResponseAtom);
-  const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllEmailDomain } = useSuperAdminEmail();
 
   const isEmptyEmailDomain = emailDomain.empty;
 
   useEffect(() => {
     const nowPage = Number(searchParams.get('page'));
-    const searchValue = userInputRef.current?.value || '';
+    const searchValue = searchParams.get('name') || '';
 
     fetchAllEmailDomain(nowPage, pageSize, searchValue);
   }, [searchParams]);
@@ -51,7 +50,7 @@ function SuperAdminEmailDomainList() {
       }}
     >
       <>
-        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAllEmailDomain} />
+        <SuperAdminSearchBar />
         <ContentContainer justifyCenter={isEmptyEmailDomain} className={'content-container'}>
           <SuperAdminSearchContents contents={emailDomain} target={'이메일'} ContentComponent={SuperAdminEmailDomainContent} />
         </ContentContainer>

--- a/src/pages/super-admin/SuperAdminEmailDomainList.tsx
+++ b/src/pages/super-admin/SuperAdminEmailDomainList.tsx
@@ -35,7 +35,7 @@ function SuperAdminEmailDomainList() {
     const nowPage = Number(searchParams.get('page'));
     const searchValue = userInputRef.current?.value || '';
 
-    fetchAllEmailDomain(nowPage, pageSize, searchValue, true);
+    fetchAllEmailDomain(nowPage, pageSize, searchValue);
   }, [searchParams]);
 
   return (
@@ -59,7 +59,7 @@ function SuperAdminEmailDomainList() {
           totalPageCount={emailDomain.totalPages}
           paginateFunction={(page: number) => {
             searchParams.set('page', page.toString());
-            setSearchParams(searchParams, { replace: false });
+            setSearchParams(searchParams);
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminManage.tsx
+++ b/src/pages/super-admin/SuperAdminManage.tsx
@@ -1,9 +1,9 @@
 import ImageRouteButton from '@components/common/button/ImageRouteButton';
 import AppContainer from '@components/common/container/AppContainer';
 import styled from '@emotion/styled';
+import useCustomNavigate from '@hooks/useCustomNavigate';
 import orderImage from '@resources/image/orderImage.png';
 import { colFlex, rowFlex } from '@styles/flexStyles';
-import { useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   width: 100%;
@@ -16,14 +16,14 @@ const ButtonContainer = styled.div`
 `;
 
 function SuperAdminManage() {
-  const navigate = useNavigate();
+  const { navigateWithPage } = useCustomNavigate();
   return (
     <AppContainer useFlex={colFlex({ justify: 'center' })} titleNavBarProps={{ title: '관리 페이지' }}>
       <Container>
         <ButtonContainer>
-          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/workspace?page=0')} buttonText={'워크스페이스 조회'} />
-          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/user?page=0')} buttonText={'사용자 조회'} />
-          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/email?page=0')} buttonText={'이메일 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigateWithPage('/super-admin/workspace')} buttonText={'워크스페이스 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigateWithPage('/super-admin/user')} buttonText={'사용자 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigateWithPage('/super-admin/email')} buttonText={'이메일 조회'} />
         </ButtonContainer>
       </Container>
     </AppContainer>

--- a/src/pages/super-admin/SuperAdminManage.tsx
+++ b/src/pages/super-admin/SuperAdminManage.tsx
@@ -21,9 +21,9 @@ function SuperAdminManage() {
     <AppContainer useFlex={colFlex({ justify: 'center' })} titleNavBarProps={{ title: '관리 페이지' }}>
       <Container>
         <ButtonContainer>
-          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/workspace')} buttonText={'워크스페이스 조회'} />
-          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/user')} buttonText={'사용자 조회'} />
-          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/email')} buttonText={'이메일 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/workspace?page=0')} buttonText={'워크스페이스 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/user?page=0')} buttonText={'사용자 조회'} />
+          <ImageRouteButton src={orderImage} onClick={() => navigate('/super-admin/email?page=0')} buttonText={'이메일 조회'} />
         </ButtonContainer>
       </Container>
     </AppContainer>

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -23,7 +23,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminUser() {
   const pageSize = 6;
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [users, setUsers] = useState<PaginationResponse<User>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllUsers } = useSuperAdminUser();
@@ -58,7 +58,8 @@ function SuperAdminUser() {
         <Pagination
           totalPageCount={users.totalPages}
           paginateFunction={(page: number) => {
-            fetchAndSetUsers(page, pageSize, userInputRef.current?.value);
+            searchParams.set('page', page.toString());
+            setSearchParams(searchParams, { replace: false });
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -39,7 +39,7 @@ function SuperAdminUser() {
     const searchValue = searchParams.get('name') || '';
 
     fetchAndSetUsers(nowPage, pageSize, searchValue);
-  }, [searchParams]);
+  }, [searchParams.toString()]);
 
   return (
     <AppContainer

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -6,7 +6,7 @@ import Pagination from '@components/common/pagination/Pagination';
 import AppContainer from '@components/common/container/AppContainer';
 import useSuperAdminUser from '@hooks/super-admin/useSuperAdminUser';
 import SuperAdminUserContent from '@components/super-admin/user/SuperAdminUserContent';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
 import { PaginationResponse, User } from '@@types/index';
 import { defaultPaginationValue } from '@@types/PaginationType';
@@ -23,20 +23,24 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminUser() {
   const pageSize = 6;
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [users, setUsers] = useState<PaginationResponse<User>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllUsers } = useSuperAdminUser();
 
   const isEmptyUsers = users.empty;
 
-  const fetchAndSetUsers = async (page: number, size: number, name: string | undefined) => {
-    const userResponse = await fetchAllUsers(page, size, name);
+  const fetchAndSetUsers = async (page: number, size: number, name: string | undefined, replace?: boolean) => {
+    const userResponse = await fetchAllUsers(page, size, name, replace ?? false);
     setUsers(userResponse);
   };
 
   useEffect(() => {
-    fetchAndSetUsers(0, pageSize, '');
-  }, []);
+    const nowPage = Number(searchParams.get('page'));
+    const searchValue = userInputRef.current?.value || '';
+
+    fetchAndSetUsers(nowPage, pageSize, searchValue, true);
+  }, [searchParams]);
 
   return (
     <AppContainer

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -30,8 +30,8 @@ function SuperAdminUser() {
 
   const isEmptyUsers = users.empty;
 
-  const fetchAndSetUsers = async (page: number, size: number, name: string | undefined, replace?: boolean) => {
-    const userResponse = await fetchAllUsers(page, size, name, replace ?? false);
+  const fetchAndSetUsers = async (page: number, size: number, name: string | undefined, replace: boolean = false) => {
+    const userResponse = await fetchAllUsers(page, size, name, replace);
     setUsers(userResponse);
   };
 

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -30,8 +30,8 @@ function SuperAdminUser() {
 
   const isEmptyUsers = users.empty;
 
-  const fetchAndSetUsers = async (page: number, size: number, name: string | undefined, replace: boolean = false) => {
-    const userResponse = await fetchAllUsers(page, size, name, replace);
+  const fetchAndSetUsers = async (page: number, size: number, name: string | undefined) => {
+    const userResponse = await fetchAllUsers(page, size, name);
     setUsers(userResponse);
   };
 
@@ -39,7 +39,7 @@ function SuperAdminUser() {
     const nowPage = Number(searchParams.get('page'));
     const searchValue = userInputRef.current?.value || '';
 
-    fetchAndSetUsers(nowPage, pageSize, searchValue, true);
+    fetchAndSetUsers(nowPage, pageSize, searchValue);
   }, [searchParams]);
 
   return (
@@ -59,7 +59,7 @@ function SuperAdminUser() {
           totalPageCount={users.totalPages}
           paginateFunction={(page: number) => {
             searchParams.set('page', page.toString());
-            setSearchParams(searchParams, { replace: false });
+            setSearchParams(searchParams);
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminUser.tsx
+++ b/src/pages/super-admin/SuperAdminUser.tsx
@@ -1,7 +1,7 @@
 import SuperAdminSearchBar from '@components/super-admin/workspace/SuperAdminSearchBar';
 import styled from '@emotion/styled';
 import { colFlex } from '@styles/flexStyles';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Pagination from '@components/common/pagination/Pagination';
 import AppContainer from '@components/common/container/AppContainer';
 import useSuperAdminUser from '@hooks/super-admin/useSuperAdminUser';
@@ -25,7 +25,6 @@ function SuperAdminUser() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [users, setUsers] = useState<PaginationResponse<User>>(defaultPaginationValue);
-  const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllUsers } = useSuperAdminUser();
 
   const isEmptyUsers = users.empty;
@@ -37,7 +36,7 @@ function SuperAdminUser() {
 
   useEffect(() => {
     const nowPage = Number(searchParams.get('page'));
-    const searchValue = userInputRef.current?.value || '';
+    const searchValue = searchParams.get('name') || '';
 
     fetchAndSetUsers(nowPage, pageSize, searchValue);
   }, [searchParams]);
@@ -51,7 +50,7 @@ function SuperAdminUser() {
       titleNavBarProps={{ title: '전체 유저 관리', onLeftArrowClick: () => navigate('/super-admin/manage') }}
     >
       <>
-        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAndSetUsers} />
+        <SuperAdminSearchBar />
         <ContentContainer justifyCenter={isEmptyUsers} className={'content-container'}>
           <SuperAdminSearchContents contents={users} target={'유저'} ContentComponent={SuperAdminUserContent} />
         </ContentContainer>

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -38,7 +38,7 @@ function SuperAdminWorkspace() {
     const searchValue = searchParams.get('name') || '';
 
     fetchAndSetWorkspaces(nowPage, pageSize, searchValue);
-  }, [searchParams]);
+  }, [searchParams.toString()]);
 
   return (
     <AppContainer

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -23,7 +23,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminWorkspace() {
   const pageSize = 6;
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [workspaces, setWorkspaces] = useState<PaginationResponse<Workspace>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement | null>(null);
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
@@ -57,7 +57,8 @@ function SuperAdminWorkspace() {
         <Pagination
           totalPageCount={workspaces.totalPages}
           paginateFunction={(page: number) => {
-            fetchAndSetWorkspaces(page, pageSize, userInputRef.current?.value);
+            searchParams.set('page', page.toString());
+            setSearchParams(searchParams, { replace: false });
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -29,8 +29,8 @@ function SuperAdminWorkspace() {
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
   const isEmptyWorkspaces = workspaces.empty;
 
-  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined, replace?: boolean) => {
-    const workspaceResponse = await fetchAllWorkspaces(page, size, name, replace ?? false);
+  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined, replace: boolean = false) => {
+    const workspaceResponse = await fetchAllWorkspaces(page, size, name, replace);
     setWorkspaces(workspaceResponse);
   };
 

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -28,13 +28,13 @@ function SuperAdminWorkspace() {
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
   const isEmptyWorkspaces = workspaces.empty;
 
-  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined) => {
-    const workspaceResponse = await fetchAllWorkspaces(page, size, name);
+  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined, replace?: boolean) => {
+    const workspaceResponse = await fetchAllWorkspaces(page, size, name, replace ?? false);
     setWorkspaces(workspaceResponse);
   };
 
   useEffect(() => {
-    fetchAndSetWorkspaces(0, pageSize, '');
+    fetchAndSetWorkspaces(0, pageSize, '', true);
   }, []);
 
   return (

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -8,7 +8,7 @@ import SuperAdminWorkspaceContent from '@components/super-admin/workspace/SuperA
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
 import { PaginationResponse, Workspace } from '@@types/index';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { defaultPaginationValue } from '@@types/PaginationType';
 
 const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
@@ -25,7 +25,6 @@ function SuperAdminWorkspace() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [workspaces, setWorkspaces] = useState<PaginationResponse<Workspace>>(defaultPaginationValue);
-  const userInputRef = useRef<HTMLInputElement | null>(null);
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
   const isEmptyWorkspaces = workspaces.empty;
 
@@ -36,7 +35,7 @@ function SuperAdminWorkspace() {
 
   useEffect(() => {
     const nowPage = Number(searchParams.get('page'));
-    const searchValue = userInputRef.current?.value || '';
+    const searchValue = searchParams.get('name') || '';
 
     fetchAndSetWorkspaces(nowPage, pageSize, searchValue);
   }, [searchParams]);
@@ -50,7 +49,7 @@ function SuperAdminWorkspace() {
       titleNavBarProps={{ title: '전체 워크스페이스 관리', onLeftArrowClick: () => navigate('/super-admin/manage') }}
     >
       <>
-        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAndSetWorkspaces} />
+        <SuperAdminSearchBar />
         <ContentContainer justifyCenter={isEmptyWorkspaces} className={'content-container'}>
           <SuperAdminSearchContents contents={workspaces} target={'워크스페이스'} ContentComponent={SuperAdminWorkspaceContent} />
         </ContentContainer>
@@ -58,7 +57,7 @@ function SuperAdminWorkspace() {
           totalPageCount={workspaces.totalPages}
           paginateFunction={(page: number) => {
             searchParams.set('page', page.toString());
-            setSearchParams(searchParams, { replace: false });
+            setSearchParams(searchParams);
           }}
         />
       </>

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -36,12 +36,9 @@ function SuperAdminWorkspace() {
 
   useEffect(() => {
     const nowPage = Number(searchParams.get('page'));
+    const searchValue = userInputRef.current?.value || '';
 
-    if (userInputRef.current?.value === null) {
-      fetchAndSetWorkspaces(nowPage, pageSize, '', true);
-    } else {
-      fetchAndSetWorkspaces(nowPage, pageSize, userInputRef.current?.value, true);
-    }
+    fetchAndSetWorkspaces(nowPage, pageSize, searchValue, true);
   }, [searchParams]);
 
   return (

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import useSuperAdminWorkspace from '@hooks/super-admin/useSuperAdminWorkspace';
 import { colFlex } from '@styles/flexStyles';
 import SuperAdminWorkspaceContent from '@components/super-admin/workspace/SuperAdminWorkspaceContent';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
 import { PaginationResponse, Workspace } from '@@types/index';
 import { useEffect, useRef, useState } from 'react';
@@ -23,6 +23,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 function SuperAdminWorkspace() {
   const pageSize = 6;
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [workspaces, setWorkspaces] = useState<PaginationResponse<Workspace>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement | null>(null);
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
@@ -34,8 +35,14 @@ function SuperAdminWorkspace() {
   };
 
   useEffect(() => {
-    fetchAndSetWorkspaces(0, pageSize, '', true);
-  }, []);
+    const nowPage = Number(searchParams.get('page'));
+
+    if (userInputRef.current?.value === null) {
+      fetchAndSetWorkspaces(nowPage, pageSize, '', true);
+    } else {
+      fetchAndSetWorkspaces(nowPage, pageSize, userInputRef.current?.value, true);
+    }
+  }, [searchParams]);
 
   return (
     <AppContainer

--- a/src/pages/super-admin/SuperAdminWorkspace.tsx
+++ b/src/pages/super-admin/SuperAdminWorkspace.tsx
@@ -29,8 +29,8 @@ function SuperAdminWorkspace() {
   const { fetchAllWorkspaces } = useSuperAdminWorkspace();
   const isEmptyWorkspaces = workspaces.empty;
 
-  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined, replace: boolean = false) => {
-    const workspaceResponse = await fetchAllWorkspaces(page, size, name, replace);
+  const fetchAndSetWorkspaces = async (page: number, size: number, name: string | undefined) => {
+    const workspaceResponse = await fetchAllWorkspaces(page, size, name);
     setWorkspaces(workspaceResponse);
   };
 
@@ -38,7 +38,7 @@ function SuperAdminWorkspace() {
     const nowPage = Number(searchParams.get('page'));
     const searchValue = userInputRef.current?.value || '';
 
-    fetchAndSetWorkspaces(nowPage, pageSize, searchValue, true);
+    fetchAndSetWorkspaces(nowPage, pageSize, searchValue);
   }, [searchParams]);
 
   return (

--- a/src/pages/user/UserEmailDomain.tsx
+++ b/src/pages/user/UserEmailDomain.tsx
@@ -1,7 +1,7 @@
 import SuperAdminSearchBar from '@components/super-admin/workspace/SuperAdminSearchBar';
 import styled from '@emotion/styled';
 import { colFlex } from '@styles/flexStyles';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Pagination from '@components/common/pagination/Pagination';
 import AppContainer from '@components/common/container/AppContainer';
 import SuperAdminSearchContents from '@components/super-admin/SuperAdminSearchContents';
@@ -24,7 +24,6 @@ function UserEmailDomain() {
   const pageSize = 6;
   const [searchParams, setSearchParams] = useSearchParams();
   const [emailDomain, setEmailDomain] = useState<PaginationResponse<EmailDomain>>(defaultPaginationValue);
-  const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllEmailDomain } = useEmail();
 
   const isEmptyEmailDomain = emailDomain.empty;
@@ -36,7 +35,7 @@ function UserEmailDomain() {
 
   useEffect(() => {
     const nowPage = Number(searchParams.get('page'));
-    const searchValue = userInputRef.current?.value || '';
+    const searchValue = searchParams.get('name') || '';
 
     fetchAndSetEmailDomain(nowPage, pageSize, searchValue);
   }, [searchParams]);
@@ -50,7 +49,7 @@ function UserEmailDomain() {
       titleNavBarProps={{ title: '이메일 도메인 조회', useBackIcon: false }}
     >
       <>
-        <SuperAdminSearchBar ref={userInputRef} fetchContents={fetchAndSetEmailDomain} />
+        <SuperAdminSearchBar />
         <ContentContainer justifyCenter={isEmptyEmailDomain} className={'content-container'}>
           <SuperAdminSearchContents contents={emailDomain} target={'유저'} ContentComponent={EmailDomainContent} />
         </ContentContainer>

--- a/src/pages/user/UserEmailDomain.tsx
+++ b/src/pages/user/UserEmailDomain.tsx
@@ -29,8 +29,8 @@ function UserEmailDomain() {
 
   const isEmptyEmailDomain = emailDomain.empty;
 
-  const fetchAndSetEmailDomain = async (page: number, size: number, name: string | undefined, replace: boolean = false) => {
-    const emailResponse = await fetchAllEmailDomain(page, size, name, replace);
+  const fetchAndSetEmailDomain = async (page: number, size: number, name: string | undefined) => {
+    const emailResponse = await fetchAllEmailDomain(page, size, name);
     setEmailDomain(emailResponse);
   };
 
@@ -38,7 +38,7 @@ function UserEmailDomain() {
     const nowPage = Number(searchParams.get('page'));
     const searchValue = userInputRef.current?.value || '';
 
-    fetchAndSetEmailDomain(nowPage, pageSize, searchValue, true);
+    fetchAndSetEmailDomain(nowPage, pageSize, searchValue);
   }, [searchParams]);
 
   return (

--- a/src/pages/user/UserEmailDomain.tsx
+++ b/src/pages/user/UserEmailDomain.tsx
@@ -38,7 +38,7 @@ function UserEmailDomain() {
     const searchValue = searchParams.get('name') || '';
 
     fetchAndSetEmailDomain(nowPage, pageSize, searchValue);
-  }, [searchParams]);
+  }, [searchParams.toString()]);
 
   return (
     <AppContainer
@@ -57,7 +57,7 @@ function UserEmailDomain() {
           totalPageCount={emailDomain.totalPages}
           paginateFunction={(page: number) => {
             searchParams.set('page', page.toString());
-            setSearchParams(searchParams, { replace: false });
+            setSearchParams(searchParams);
           }}
         />
       </>

--- a/src/pages/user/UserEmailDomain.tsx
+++ b/src/pages/user/UserEmailDomain.tsx
@@ -29,8 +29,8 @@ function UserEmailDomain() {
 
   const isEmptyEmailDomain = emailDomain.empty;
 
-  const fetchAndSetEmailDomain = async (page: number, size: number, name: string | undefined, replace?: boolean) => {
-    const emailResponse = await fetchAllEmailDomain(page, size, name, replace ?? false);
+  const fetchAndSetEmailDomain = async (page: number, size: number, name: string | undefined, replace: boolean = false) => {
+    const emailResponse = await fetchAllEmailDomain(page, size, name, replace);
     setEmailDomain(emailResponse);
   };
 

--- a/src/pages/user/UserEmailDomain.tsx
+++ b/src/pages/user/UserEmailDomain.tsx
@@ -9,6 +9,7 @@ import { EmailDomain, PaginationResponse } from '@@types/index';
 import { defaultPaginationValue } from '@@types/PaginationType';
 import useEmail from '@hooks/user/useEmail';
 import EmailDomainContent from '@components/user/email/EmailDomainContent';
+import { useSearchParams } from 'react-router-dom';
 
 const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
   height: 550px;
@@ -21,20 +22,24 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 
 function UserEmailDomain() {
   const pageSize = 6;
+  const [searchParams] = useSearchParams();
   const [emailDomain, setEmailDomain] = useState<PaginationResponse<EmailDomain>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllEmailDomain } = useEmail();
 
   const isEmptyEmailDomain = emailDomain.empty;
 
-  const fetchAndSetEmailDomain = async (page: number, size: number, name: string | undefined) => {
-    const emailResponse = await fetchAllEmailDomain(page, size, name);
+  const fetchAndSetEmailDomain = async (page: number, size: number, name: string | undefined, replace?: boolean) => {
+    const emailResponse = await fetchAllEmailDomain(page, size, name, replace ?? false);
     setEmailDomain(emailResponse);
   };
 
   useEffect(() => {
-    fetchAndSetEmailDomain(0, pageSize, '');
-  }, []);
+    const nowPage = Number(searchParams.get('page'));
+    const searchValue = userInputRef.current?.value || '';
+
+    fetchAndSetEmailDomain(nowPage, pageSize, searchValue, true);
+  }, [searchParams]);
 
   return (
     <AppContainer

--- a/src/pages/user/UserEmailDomain.tsx
+++ b/src/pages/user/UserEmailDomain.tsx
@@ -22,7 +22,7 @@ const ContentContainer = styled.div<{ justifyCenter?: boolean }>`
 
 function UserEmailDomain() {
   const pageSize = 6;
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [emailDomain, setEmailDomain] = useState<PaginationResponse<EmailDomain>>(defaultPaginationValue);
   const userInputRef = useRef<HTMLInputElement>(null);
   const { fetchAllEmailDomain } = useEmail();
@@ -57,7 +57,8 @@ function UserEmailDomain() {
         <Pagination
           totalPageCount={emailDomain.totalPages}
           paginateFunction={(page: number) => {
-            fetchAndSetEmailDomain(page, pageSize, userInputRef.current?.value);
+            searchParams.set('page', page.toString());
+            setSearchParams(searchParams, { replace: false });
           }}
         />
       </>


### PR DESCRIPTION
## 📚 개요

https://github.com/user-attachments/assets/fc4f66b7-4a18-461a-9bc7-5b4ddf7fa212

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- `setSearchParams`의 `replace`옵션을 추가하여 구현했습니다.
```js
setSearchParams(searchParams, { replace });
```

- 다른 page를 이동했다가 뒤로 가기 클릭 시 이전 page 내용이 안 불러와지는 버그를 수정했습니다.
- `useEffect`에서 `searchParams`를 의존성 배열에 넣어 page가 변경될 때 마다 바뀐 page 내용을 불러옵니다.
```js
  useEffect(() => {
    const nowPage = Number(searchParams.get('page'));
    const searchValue = userInputRef.current?.value || '';

    fetchAndSetWorkspaces(nowPage, pageSize, searchValue, true);
  }, [searchParams]);
```
