### PR TITLE
FIX - 실시간 주문 조회 페이지 미반영된 디자인 반

### DIFF
--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -14,7 +14,7 @@ import { useParams } from 'react-router-dom';
 import OrderDetailModal from '@components/admin/order/modal/OrderDetailModal';
 import { extractMinFromDate } from '@utils/FormatDate';
 import { areOrdersEquivalent } from '@utils/MemoCompareFunction';
-import useModal from '@hooks/useModal'; // 새로 만든 커스텀 훅 import
+import useModal from '@hooks/useModal';
 
 const CardContainer = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })}

--- a/src/components/admin/order/modal/OrderModalHeaderContents.tsx
+++ b/src/components/admin/order/modal/OrderModalHeaderContents.tsx
@@ -12,7 +12,7 @@ const ModalHeader = styled.div`
   ${colFlex({ justify: 'space-between', align: 'start' })}
   gap: 10px;
   padding: 40px 40px 20px 40px;
-  border-bottom: 20px solid ${Color.LIGHT_GREY};
+  border-bottom: 12px solid ${Color.LIGHT_GREY};
 `;
 
 const ModalHeaderTitle = styled.div`

--- a/src/components/admin/order/modal/OrderModalMainContents.tsx
+++ b/src/components/admin/order/modal/OrderModalMainContents.tsx
@@ -119,7 +119,7 @@ function OrderModalMainContents({ order }: OrderModalMainContentsProps) {
             </ProductRightContainer>
             <ProductLeftContainer>
               <AppLabel color={Color.BLACK} size={20}>
-                {`${orderProduct.productPrice * orderProduct.servedCount}원`}
+                {`${(orderProduct.productPrice * orderProduct.servedCount).toLocaleString()}원`}
               </AppLabel>
               {isPaidStatus && (
                 <ButtonContainer>
@@ -148,7 +148,7 @@ function OrderModalMainContents({ order }: OrderModalMainContentsProps) {
           {'상품 합계'}
         </AppLabel>
         <AppLabel color={Color.BLACK} size={20} style={{ fontWeight: 700 }}>
-          {`${order.totalPrice}원`}
+          {`${order.totalPrice.toLocaleString()}원`}
         </AppLabel>
       </TotalLabelContainer>
     </ModalContent>

--- a/src/components/admin/order/modal/OrderModalMainContents.tsx
+++ b/src/components/admin/order/modal/OrderModalMainContents.tsx
@@ -119,7 +119,7 @@ function OrderModalMainContents({ order }: OrderModalMainContentsProps) {
             </ProductRightContainer>
             <ProductLeftContainer>
               <AppLabel color={Color.BLACK} size={20}>
-                {`${orderProduct.productPrice.toLocaleString()}원`}
+                {`${orderProduct.productPrice * orderProduct.servedCount}원`}
               </AppLabel>
               {isPaidStatus && (
                 <ButtonContainer>
@@ -148,7 +148,7 @@ function OrderModalMainContents({ order }: OrderModalMainContentsProps) {
           {'상품 합계'}
         </AppLabel>
         <AppLabel color={Color.BLACK} size={20} style={{ fontWeight: 700 }}>
-          {`${order.totalPrice.toLocaleString()}원`}
+          {`${order.totalPrice}원`}
         </AppLabel>
       </TotalLabelContainer>
     </ModalContent>

--- a/src/components/admin/order/modal/OrderModalMainContents.tsx
+++ b/src/components/admin/order/modal/OrderModalMainContents.tsx
@@ -12,7 +12,7 @@ import { useParams } from 'react-router-dom';
 
 const HorizontalLine = styled.hr`
   width: 100%;
-  border: 0.3px solid #eeecec;
+  border: 1px solid #eeecec;
 `;
 
 const ModalContent = styled.div`

--- a/src/components/common/modal/LoadingModal.tsx
+++ b/src/components/common/modal/LoadingModal.tsx
@@ -5,7 +5,7 @@ import { isLoadingAtom } from '@recoils/atoms';
 import { rowFlex } from '@styles/flexStyles';
 
 const Container = styled.div`
-  z-index: 1002;
+  z-index: 5002;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
## 📚 개요


https://github.com/user-attachments/assets/04540142-c659-4531-ad85-3ead0f8feeaf

- 상세 주문 모달창의 수평선에 대한 height를 디자인에 맞춰 적용했습니다.
- 상품 옆의 가격을 서빙된 상품의 개수에 맞춰 동적으로 보여줍니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- 상품 합계 가격은 동적으로 보여주지 않아도 괜찮은 건지 궁금합니다!