### PR TITLE
FIX - AdminOrderTableHistory 진입 시 navigateWithPage 사용하게 수정

### DIFF
--- a/src/pages/admin/order/AdminOrder.tsx
+++ b/src/pages/admin/order/AdminOrder.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
 `;
 
 function AdminOrder() {
-  const { replaceLastPath } = useCustomNavigate();
+  const { replaceLastPath, navigateWithPage } = useCustomNavigate();
 
   return (
     <AppContainer
@@ -26,7 +26,7 @@ function AdminOrder() {
         <ButtonContainer className={'button-container'}>
           <ImageRouteButton src={orderImage} onClick={() => replaceLastPath('/order/realtime')} buttonText={'실시간 주문 조회'} />
           <ImageRouteButton src={orderHistoryImage} onClick={() => replaceLastPath('/order/history')} buttonText={'전체 주문 조회'} />
-          <ImageRouteButton src={orderManageImage} onClick={() => replaceLastPath('/order/table')} buttonText={'테이블별 주문 조회'} />
+          <ImageRouteButton src={orderManageImage} onClick={() => navigateWithPage('/order/table')} buttonText={'테이블별 주문 조회'} />
         </ButtonContainer>
         <AppFooter />
       </Container>


### PR DESCRIPTION
## 📚 개요

```js
<ImageRouteButton onClick={() => navigateWithPage('/order/table')} buttonText={'테이블별 주문 조회'} />
```
- 기존 replaceLastPath대신 navigateWithPage로 대체했습니다.
## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

리뷰가 비교적 꼼꼼히 이루어져야할 부분이나 파일을 여기다 적어주거나
해당 로직에 직접 코멘트를 달아도 좋습니다