### PR TITLE
EDIT - 테이블 관리 페이지에 html-to-image 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react-datepicker": "^6.0.1",
     "@types/react-dom": "^18.0.6",
     "axios": "1.6.0",
+    "html-to-image": "^1.11.11",
     "jsqr": "^1.4.0",
     "lodash": "^4.17.21",
     "qrcode.react": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5349,6 +5349,11 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
+html-to-image@^1.11.11:
+  version "1.11.11"
+  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.11.11.tgz#c0f8a34dc9e4b97b93ff7ea286eb8562642ebbea"
+  integrity sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==
+
 html-webpack-plugin@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50"


### PR DESCRIPTION
## 📚 개요

- 테이블 관리 페이지에 html-to-image를 적용하여 qr코드를 다운받을 때 테이블 번호도 같이 다운받도록 수정했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

다운로드 된 사진
![image](https://github.com/user-attachments/assets/82312592-7c2d-4dd1-b1cd-039597222819)
