### PR TITLE
ADD - QR 코드 전체 다운로드 기능 추가

### DIFF
--- a/src/components/admin/order/AdminOrderManageTitleNavBarChildren.tsx
+++ b/src/components/admin/order/AdminOrderManageTitleNavBarChildren.tsx
@@ -5,6 +5,7 @@ import { rowFlex } from '@styles/flexStyles';
 interface Props {
   tableCount: number;
   handleTableCount: (tableNo: number) => void;
+  downloadQrCode: () => void;
 }
 
 const ButtonContainer = styled.div`
@@ -12,7 +13,7 @@ const ButtonContainer = styled.div`
   ${rowFlex({ align: 'center' })}
 `;
 
-function AdminTableCountTitleNavBarChildren({ handleTableCount, tableCount }: Props) {
+function AdminTableCountTitleNavBarChildren({ handleTableCount, downloadQrCode, tableCount }: Props) {
   return (
     <ButtonContainer className={'button-container'}>
       <RoundedAppButton
@@ -30,6 +31,7 @@ function AdminTableCountTitleNavBarChildren({ handleTableCount, tableCount }: Pr
       >
         테이블 삭제
       </RoundedAppButton>
+      <RoundedAppButton onClick={downloadQrCode}>QR코드 전체 다운로드</RoundedAppButton>
     </ButtonContainer>
   );
 }

--- a/src/pages/admin/order/AdminTableCount.tsx
+++ b/src/pages/admin/order/AdminTableCount.tsx
@@ -46,6 +46,7 @@ const QRCodeCard = styled.div`
   background: ${Color.WHITE};
   gap: 10px;
   width: 200px;
+  height: 200px;
   border-radius: 20px;
   box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.1);
   padding: 10px;

--- a/src/pages/admin/order/AdminTableCount.tsx
+++ b/src/pages/admin/order/AdminTableCount.tsx
@@ -10,8 +10,8 @@ import { Color } from '@resources/colors';
 import useAdminWorkspace from '@hooks/admin/useAdminWorkspace';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { adminWorkspaceAtom } from '@recoils/atoms';
-import { toPng } from 'html-to-image';
 import PreviewContainer from '@components/common/container/PreviewContainer';
+import { toPng } from 'html-to-image';
 
 const Container = styled.div`
   width: 100vw;
@@ -37,27 +37,25 @@ const QRCodeContainer = styled.div`
   height: 700px;
   overflow: auto;
   grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-  padding: 10px;
-`;
-
-const QRCodeCardContainer = styled.div`
-  gap: 10px;
-  width: 200px;
-  height: 230px;
-  border-radius: 20px;
-  padding: 10px;
-  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.1);
-  ${colFlex({ align: 'center' })}
+  gap: 20px;
+  padding: 10px 20px;
 `;
 
 const QRCodeCard = styled.div`
+  ${colFlex({ align: 'center' })}
   background: ${Color.WHITE};
   gap: 10px;
   width: 200px;
-  height: 230px;
   border-radius: 20px;
-  ${colFlex({ align: 'center' })}
+  box-shadow: 0 4px 20px 0 rgba(0, 0, 0, 0.1);
+  padding: 10px;
+  box-sizing: border-box;
+`;
+
+const QRCodeImage = styled(QRCodeCanvas)`
+  width: 150px;
+  height: 150px;
+  cursor: pointer;
 `;
 
 const TableLink = styled.a`
@@ -66,16 +64,6 @@ const TableLink = styled.a`
   padding: 5px 10px;
   background: ${Color.KIO_ORANGE};
   border-radius: 10px;
-`;
-
-const QRCodeDownloadButton = styled.label`
-  width: 100px;
-  height: 30px;
-  border: 1px solid ${Color.KIO_ORANGE};
-  border-radius: 10px;
-  cursor: pointer;
-  user-select: none;
-  ${rowFlex({ justify: 'center', align: 'center' })}
 `;
 
 function AdminTableCount() {
@@ -141,15 +129,12 @@ function AdminTableCount() {
           </PreviewContainer>
           <QRCodeContainer className={'qrcode-container'}>
             {Array.from({ length: workspace.tableCount }, (_, index) => (
-              <QRCodeCardContainer key={index}>
-                <QRCodeCard className={'qrcode-card'} ref={(el) => (QRCodeRefs.current[index + 1] = el)}>
-                  <TableLink href={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} target={'_blank'}>
-                    {index + 1}번 테이블
-                  </TableLink>
-                  <QRCodeCanvas value={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} size={150} />
-                </QRCodeCard>
-                <QRCodeDownloadButton onClick={() => downloadQrCode(index + 1)}>다운로드</QRCodeDownloadButton>
-              </QRCodeCardContainer>
+              <QRCodeCard key={index} className={'qrcode-card'} ref={(el) => (QRCodeRefs.current[index + 1] = el)}>
+                <TableLink href={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} target={'_blank'}>
+                  {index + 1}번 테이블
+                </TableLink>
+                <QRCodeImage value={`${baseUrl}/order?workspaceId=${workspaceId}&tableNo=${index + 1}`} onClick={() => downloadQrCode(index + 1)} />
+              </QRCodeCard>
             ))}
           </QRCodeContainer>
         </ContentContainer>


### PR DESCRIPTION
## 📚 개요

- 테이블 개수 관리 페이지에서 개별 다운로드 버튼을 없애고 qr code 이미지에 해당 기능을 위임했습니다.
- 또한 qr code 전체 다운로드 기능을 추가했습니다.

## 🕐 리뷰 예상 시간

> 2m

## ❗❗ 중요한 변경점(Option)

전체 이미지를 가져오기 위해서 ref에서 current의 style을 직접 접근해서 고치는 부분이 있습니다.

![image](https://github.com/user-attachments/assets/7c753d87-5081-4511-afa6-7691e773a6e9)

![ITZI 주점 QR코드](https://github.com/user-attachments/assets/15ff1d6b-a2be-49be-b7b0-aa27c9d638a4)
