### PR TITLE
EDIT - 프리뷰 컴포넌트와 라우터 컴포넌트 flex align 조정

### DIFF
--- a/src/pages/admin/AdminWorkspace.tsx
+++ b/src/pages/admin/AdminWorkspace.tsx
@@ -15,7 +15,7 @@ import AppFooter from '@components/common/footer/AppFooter';
 
 const ContentContainer = styled.div`
   width: 100%;
-  ${rowFlex({ justify: 'center', align: 'center' })}
+  ${rowFlex({ justify: 'center', align: 'start' })}
   gap: 80px;
 `;
 


### PR DESCRIPTION
## 📚 개요

![image](https://github.com/user-attachments/assets/b80539a2-e630-4a9b-a1eb-3fda7cdadd90)

- 프리뷰 페이지와 라우터 컨테이너의 flex를 start로 조정했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

리뷰가 비교적 꼼꼼히 이루어져야할 부분이나 파일을 여기다 적어주거나
해당 로직에 직접 코멘트를 달아도 좋습니다