### PR TITLE
FIX - 웹소켓 엔드포인트 변경 안해서 생기는 오류 수정

### DIFF
--- a/src/hooks/user/useOrdersWebsocket.tsx
+++ b/src/hooks/user/useOrdersWebsocket.tsx
@@ -5,7 +5,7 @@ function useOrdersWebsocket(workspaceId: string | undefined) {
   const { fetchTodayOrders } = useAdminOrder(workspaceId);
 
   const subscribeOrders = () => {
-    const url = process.env.REACT_APP_ENVIRONMENT === 'development' ? 'ws://localhost:8080/ws' : 'wss://kio-school.fly.dev/ws';
+    const url = process.env.REACT_APP_ENVIRONMENT === 'development' ? 'ws://localhost:8080/ws' : 'wss://api.kio-school.com/ws';
     const client = new StompJs.Client({
       brokerURL: url,
       debug: (str) => {


### PR DESCRIPTION
## 📚 개요

- 이전에 서버 엔드포인트를 변경하면서, 웹소켓 엔드포인트는 변경하지 않아서 생긴 오류를 수정했습니다.

## 🕐 리뷰 예상 시간

> 1m

## ❗❗ 중요한 변경점(Option)

- 머지 후 바로 배포 pr 올리겠습니다.