### PR TITLE
EDIT - 카테고리 뱃지 디자인 적용

### DIFF
--- a/src/components/admin/order/OrderStickyNavBar.tsx
+++ b/src/components/admin/order/OrderStickyNavBar.tsx
@@ -20,10 +20,10 @@ const Container = styled.div<{ isShow: boolean }>`
 
 const LeftContainer = styled.div`
   padding-left: 10px;
-  width: 100px;
+  width: 300px;
   height: 100%;
   gap: 5px;
-  ${rowFlex({ justify: 'space-evenly', align: 'center' })}
+  ${rowFlex({ justify: 'start', align: 'center' })}
 `;
 
 const RightContainer = styled.div`

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import AppBadge from '@components/common/badge/AppBadge';
 import { Product, ProductCategory } from '@@types/index';
 import _ from 'lodash';
-import { rowFlex } from '@styles/flexStyles';
+import { colFlex, rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
 
 interface CategoryBadgesContainerProps {
@@ -15,7 +14,7 @@ interface CategoryBadgesContainerProps {
 const Container = styled.div`
   width: 100%;
   height: 50px;
-  padding-left: 35px;
+  padding: 0 10px;
   box-sizing: border-box;
   gap: 8px;
   overflow: scroll;
@@ -27,36 +26,83 @@ const Container = styled.div`
   }
 `;
 
+const CategoryLabel = styled.div<{ isSelected?: boolean }>`
+  width: auto;
+  padding: 0 10px;
+  border-bottom: ${({ isSelected }) => (isSelected ? '3px solid black' : 'none')};
+  ${colFlex({ justify: 'center' })}
+`;
+
 function CategoryBadgesContainer({ productCategories, productsByCategory, categoryRefs }: CategoryBadgesContainerProps) {
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+
   const scrollToCategory = (categoryId: string) => {
     const categoryElement = categoryRefs.current[categoryId];
 
-    if (categoryElement) {
-      const elementPosition = categoryElement.getBoundingClientRect().top;
-      const headerHeight = 110;
-      const offsetPosition = elementPosition + window.scrollY - headerHeight;
-
-      window.scrollTo({
-        top: offsetPosition,
-        behavior: 'smooth',
-      });
+    if (!categoryElement) {
+      return;
     }
+
+    const elementPosition = categoryElement.getBoundingClientRect().top;
+    const headerHeight = 110;
+    const offsetPosition = elementPosition + window.scrollY - headerHeight;
+
+    window.scrollTo({
+      top: offsetPosition,
+      behavior: 'smooth',
+    });
   };
 
+  const updateActiveCategory = () => {
+    const headerHeight = 110;
+    const scrollPosition = window.scrollY + headerHeight;
+
+    let newActiveCategory: string | null = null;
+
+    Object.entries(categoryRefs.current).forEach(([key, element]) => {
+      if (!element) {
+        return;
+      }
+
+      const elementTop = element.offsetTop;
+      const elementHeight = element.offsetHeight;
+      const isInSectionBounds = scrollPosition >= elementTop && scrollPosition < elementTop + elementHeight;
+
+      if (isInSectionBounds) {
+        newActiveCategory = key;
+        return;
+      }
+    });
+
+    setActiveCategory(newActiveCategory);
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', updateActiveCategory);
+
+    return () => {
+      window.removeEventListener('scroll', updateActiveCategory);
+    };
+  }, []);
+
   return (
-    <Container className={'category-badges-container'}>
+    <Container className="category-badges-container">
       {productCategories.map(
         (category) =>
           productsByCategory[category.id] && (
-            <AppBadge onClick={() => scrollToCategory(String(category.id))} key={`category_${category.id}`}>
+            <CategoryLabel
+              onClick={() => scrollToCategory(String(category.id))}
+              key={`category_${category.id}`}
+              isSelected={activeCategory === String(category.id)}
+            >
               {category.name}
-            </AppBadge>
+            </CategoryLabel>
           ),
       )}
       {productsByCategory.undefined && (
-        <AppBadge onClick={() => scrollToCategory('.')} key={`category_null`}>
+        <CategoryLabel onClick={() => scrollToCategory('.')} key={`category_null`} isSelected={activeCategory === '.'}>
           기본 메뉴
-        </AppBadge>
+        </CategoryLabel>
       )}
     </Container>
   );

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -61,9 +61,7 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
     let newActiveCategory: string | null = null;
 
     Object.entries(categoryRefs.current).forEach(([key, element]) => {
-      if (!element) {
-        return;
-      }
+      if (!element) return;
 
       const elementTop = element.offsetTop;
       const elementHeight = element.offsetHeight;

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -58,22 +58,18 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
     const headerHeight = 110;
     const scrollPosition = window.scrollY + headerHeight;
 
-    let newActiveCategory: string | null = null;
-
-    Object.entries(categoryRefs.current).forEach(([key, element]) => {
-      if (!element) return;
+    for (const [categoryId, element] of Object.entries(categoryRefs.current)) {
+      if (!element) continue;
 
       const elementTop = element.offsetTop;
       const elementHeight = element.offsetHeight;
       const isInSectionBounds = scrollPosition >= elementTop && scrollPosition < elementTop + elementHeight;
 
       if (isInSectionBounds) {
-        newActiveCategory = key;
-        return;
+        setActiveCategory(categoryId);
+        break;
       }
-    });
-
-    setActiveCategory(newActiveCategory);
+    }
   };
 
   useEffect(() => {

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -6,12 +6,6 @@ import { rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
 import { scrollToCategory, scrollToCategoryBadge } from '@utils/CategoryTracking';
 
-interface CategoryBadgesContainerProps {
-  productCategories: ProductCategory[];
-  productsByCategory: _.Dictionary<Product[]>;
-  categoryRefs: React.MutableRefObject<Record<string, HTMLDivElement | null>>;
-}
-
 const Container = styled.div`
   width: 100%;
   height: 50px;
@@ -33,6 +27,12 @@ const CategoryLabel = styled.div<{ isSelected?: boolean }>`
   padding: 0 10px;
   border-bottom: 3px solid ${({ isSelected }) => (isSelected ? 'black' : 'transparent')};
 `;
+
+interface CategoryBadgesContainerProps {
+  productCategories: ProductCategory[];
+  productsByCategory: _.Dictionary<Product[]>;
+  categoryRefs: React.MutableRefObject<Record<string, HTMLDivElement | null>>;
+}
 
 function CategoryBadgesContainer({ productCategories, productsByCategory, categoryRefs }: CategoryBadgesContainerProps) {
   const [activeCategory, setActiveCategory] = useState<string | null>(null);

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -43,13 +43,12 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
   const handleCategoryClick = (categoryId: string) => {
     isManualScrollRef.current = true;
 
-    setActiveCategory(categoryId);
     scrollToCategoryBadge(categoryId, containerRef);
-    scrollToCategory(categoryId, categoryRefs);
+    scrollToCategory(categoryId, categoryRefs, () => {
+      setActiveCategory(categoryId);
+    });
 
-    setTimeout(() => {
-      isManualScrollRef.current = false;
-    }, 500);
+    isManualScrollRef.current = false;
   };
 
   const updateActiveCategory = () => {

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -46,9 +46,8 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
     scrollToCategoryBadge(categoryId, containerRef);
     scrollToCategory(categoryId, categoryRefs, () => {
       setActiveCategory(categoryId);
+      isManualScrollRef.current = false;
     });
-
-    isManualScrollRef.current = false;
   };
 
   const updateActiveCategory = () => {

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -38,12 +38,23 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const isManualScrollRef = useRef(false);
+
   const handleCategoryClick = (categoryId: string) => {
-    scrollToCategory(categoryId, categoryRefs);
+    isManualScrollRef.current = true;
+
+    setActiveCategory(categoryId);
     scrollToCategoryBadge(categoryId, containerRef);
+    scrollToCategory(categoryId, categoryRefs);
+
+    setTimeout(() => {
+      isManualScrollRef.current = false;
+    }, 500);
   };
 
   const updateActiveCategory = () => {
+    if (isManualScrollRef.current) return;
+
     const headerHeight = 110;
     const scrollPosition = window.scrollY + headerHeight;
 

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -4,6 +4,7 @@ import { Product, ProductCategory } from '@@types/index';
 import _ from 'lodash';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
+import { scrollToCategory } from '@utils/CategoryTracking';
 
 interface CategoryBadgesContainerProps {
   productCategories: ProductCategory[];
@@ -35,23 +36,6 @@ const CategoryLabel = styled.div<{ isSelected?: boolean }>`
 
 function CategoryBadgesContainer({ productCategories, productsByCategory, categoryRefs }: CategoryBadgesContainerProps) {
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
-
-  const scrollToCategory = (categoryId: string) => {
-    const categoryElement = categoryRefs.current[categoryId];
-
-    if (!categoryElement) {
-      return;
-    }
-
-    const elementPosition = categoryElement.getBoundingClientRect().top;
-    const headerHeight = 110;
-    const offsetPosition = elementPosition + window.scrollY - headerHeight;
-
-    window.scrollTo({
-      top: offsetPosition,
-      behavior: 'smooth',
-    });
-  };
 
   const updateActiveCategory = () => {
     const headerHeight = 110;
@@ -91,7 +75,7 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
         (category) =>
           productsByCategory[category.id] && (
             <CategoryLabel
-              onClick={() => scrollToCategory(String(category.id))}
+              onClick={() => scrollToCategory(String(category.id), categoryRefs)}
               key={`category_${category.id}`}
               isSelected={activeCategory === String(category.id)}
             >
@@ -100,7 +84,7 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
           ),
       )}
       {productsByCategory.undefined && (
-        <CategoryLabel onClick={() => scrollToCategory('.')} key={`category_null`} isSelected={activeCategory === '.'}>
+        <CategoryLabel onClick={() => scrollToCategory('.', categoryRefs)} key={`category_null`} isSelected={activeCategory === '.'}>
           기본 메뉴
         </CategoryLabel>
       )}

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -24,7 +24,7 @@ const Container = styled.div`
 
 const CategoryLabel = styled.div<{ isSelected?: boolean }>`
   width: auto;
-  padding: 0 10px;
+  padding: 5px 10px;
   border-bottom: 3px solid ${({ isSelected }) => (isSelected ? 'black' : 'transparent')};
 `;
 

--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import styled from '@emotion/styled';
 import { Product, ProductCategory } from '@@types/index';
 import _ from 'lodash';
-import { colFlex, rowFlex } from '@styles/flexStyles';
+import { rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
-import { scrollToCategory } from '@utils/CategoryTracking';
+import { scrollToCategory, scrollToCategoryBadge } from '@utils/CategoryTracking';
 
 interface CategoryBadgesContainerProps {
   productCategories: ProductCategory[];
@@ -18,7 +18,8 @@ const Container = styled.div`
   padding: 0 10px;
   box-sizing: border-box;
   gap: 8px;
-  overflow: scroll;
+  overflow-x: auto;
+  white-space: nowrap;
   ${rowFlex({ align: 'center' })}
   border-top: 10px solid ${Color.LIGHT_GREY};
 
@@ -30,12 +31,17 @@ const Container = styled.div`
 const CategoryLabel = styled.div<{ isSelected?: boolean }>`
   width: auto;
   padding: 0 10px;
-  border-bottom: ${({ isSelected }) => (isSelected ? '3px solid black' : 'none')};
-  ${colFlex({ justify: 'center' })}
+  border-bottom: 3px solid ${({ isSelected }) => (isSelected ? 'black' : 'transparent')};
 `;
 
 function CategoryBadgesContainer({ productCategories, productsByCategory, categoryRefs }: CategoryBadgesContainerProps) {
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleCategoryClick = (categoryId: string) => {
+    scrollToCategory(categoryId, categoryRefs);
+    scrollToCategoryBadge(categoryId, containerRef);
+  };
 
   const updateActiveCategory = () => {
     const headerHeight = 110;
@@ -69,13 +75,20 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
     };
   }, []);
 
+  useEffect(() => {
+    if (activeCategory) {
+      scrollToCategoryBadge(activeCategory, containerRef);
+    }
+  }, [activeCategory]);
+
   return (
-    <Container className="category-badges-container">
+    <Container className="category-badges-container" ref={containerRef}>
       {productCategories.map(
         (category) =>
           productsByCategory[category.id] && (
             <CategoryLabel
-              onClick={() => scrollToCategory(String(category.id), categoryRefs)}
+              id={`categoryBadge_${category.id}`}
+              onClick={() => handleCategoryClick(String(category.id))}
               key={`category_${category.id}`}
               isSelected={activeCategory === String(category.id)}
             >
@@ -84,7 +97,7 @@ function CategoryBadgesContainer({ productCategories, productsByCategory, catego
           ),
       )}
       {productsByCategory.undefined && (
-        <CategoryLabel onClick={() => scrollToCategory('.', categoryRefs)} key={`category_null`} isSelected={activeCategory === '.'}>
+        <CategoryLabel id={`categoryBadge_.`} onClick={() => handleCategoryClick('.')} key={`category_null`} isSelected={activeCategory === '.'}>
           기본 메뉴
         </CategoryLabel>
       )}

--- a/src/components/user/order/OrderButton.tsx
+++ b/src/components/user/order/OrderButton.tsx
@@ -4,13 +4,7 @@ import AppButton from '@components/common/button/AppButton';
 import { rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
 
-interface OrderButtonProps {
-  showButton: boolean;
-  buttonLabel: string;
-  onClick?: () => void;
-}
-
-const OrderButtonContainer = styled.div`
+const Container = styled.div`
   position: fixed;
   bottom: 50px;
   width: 100vw;
@@ -19,23 +13,29 @@ const OrderButtonContainer = styled.div`
 `;
 
 const OrderButtonSubContainer = styled.div`
-  padding: 8px;
+  padding: 10px;
   border-radius: 20px;
   background: ${Color.WHITE};
   box-shadow: 0 16px 32px 0 rgba(194, 191, 172, 0.6);
 `;
 
+interface OrderButtonProps {
+  showButton: boolean;
+  buttonLabel: string;
+  onClick?: () => void;
+}
+
 function OrderButton({ showButton, buttonLabel, onClick }: OrderButtonProps) {
   if (!showButton) return null;
 
   return (
-    <OrderButtonContainer className={'order-button-container'}>
+    <Container className={'order-button-container'}>
       <OrderButtonSubContainer className={'order-button-sub-container'}>
-        <AppButton size={270} onClick={onClick}>
+        <AppButton size={290} onClick={onClick}>
           {buttonLabel}
         </AppButton>
       </OrderButtonSubContainer>
-    </OrderButtonContainer>
+    </Container>
   );
 }
 

--- a/src/components/user/order/OrderFooter.tsx
+++ b/src/components/user/order/OrderFooter.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
+import { colFlex } from '@styles/flexStyles';
+import React from 'react';
+
+const Container = styled.div`
+  width: 100%;
+  height: 150px;
+  background: ${Color.LIGHT_GREY};
+
+  color: ${Color.GREY};
+  ${colFlex({ justify: 'center', align: 'center' })}
+`;
+
+const Content = styled.div`
+  width: 90%;
+  height: 100%;
+  font-size: 12px;
+  line-height: 1.8;
+  ${colFlex({ justify: 'center' })}
+`;
+
+function OrderFooter() {
+  return (
+    <Container>
+      <Content>
+        유의사항 <br />
+        · 메뉴 사진은 연출된 이미지로 실제 조리된 음식과 다를 수 있습니다. <br />
+        · 상단 메뉴 및 가격은 업소에서 제공한 정보를 기준으로 작성되었으며 변동될 수 있습니다. <br />
+        · 키오스쿨은 통신판매중개자로 거래 당사자가 아니므로, 판매자가 등록한 상품정보 및 거래 등에 대해 책임을 지지 않습니다.
+        <br />
+      </Content>
+    </Container>
+  );
+}
+
+export default OrderFooter;

--- a/src/pages/user/order/Order.tsx
+++ b/src/pages/user/order/Order.tsx
@@ -12,11 +12,11 @@ import { Product } from '@@types/index';
 import _ from 'lodash';
 import OrderButton from '@components/user/order/OrderButton';
 import useProduct from '@hooks/user/useProduct';
-import AppFooter from '@components/common/footer/AppFooter';
 import { colFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
 import OrderImageSlider from '@components/admin/order/OrderImageSlider';
 import OrderStickyNavBar from '@components/admin/order/OrderStickyNavBar';
+import OrderFooter from '@components/user/order/OrderFooter';
 
 const Container = styled.div`
   width: 100%;
@@ -157,7 +157,7 @@ function Order() {
           </NormalCategoryProductsContainer>
         )}
 
-        <AppFooter fixed={false} />
+        <OrderFooter />
       </ContentContainer>
       <OrderButton
         showButton={orderBasket.length > 0}

--- a/src/utils/CategoryTracking.ts
+++ b/src/utils/CategoryTracking.ts
@@ -14,3 +14,18 @@ export const scrollToCategory = (categoryId: string, categoryRefs: React.Mutable
     behavior: 'smooth',
   });
 };
+
+export const scrollToCategoryBadge = (categoryId: string, containerRef: React.RefObject<HTMLDivElement>) => {
+  if (!containerRef.current) {
+    return;
+  }
+
+  const badgeElement = containerRef.current.querySelector(`#categoryBadge_${categoryId}`) as HTMLElement | null;
+  if (badgeElement) {
+    badgeElement.scrollIntoView({
+      behavior: 'smooth',
+      inline: 'center',
+      block: 'nearest',
+    });
+  }
+};

--- a/src/utils/CategoryTracking.ts
+++ b/src/utils/CategoryTracking.ts
@@ -1,0 +1,16 @@
+export const scrollToCategory = (categoryId: string, categoryRefs: React.MutableRefObject<Record<string, HTMLDivElement | null>>) => {
+  const categoryElement = categoryRefs.current[categoryId];
+
+  if (!categoryElement) {
+    return;
+  }
+
+  const elementPosition = categoryElement.getBoundingClientRect().top;
+  const headerHeight = 110;
+  const offsetPosition = elementPosition + window.scrollY - headerHeight;
+
+  window.scrollTo({
+    top: offsetPosition,
+    behavior: 'smooth',
+  });
+};

--- a/src/utils/CategoryTracking.ts
+++ b/src/utils/CategoryTracking.ts
@@ -1,9 +1,7 @@
 export const scrollToCategory = (categoryId: string, categoryRefs: React.MutableRefObject<Record<string, HTMLDivElement | null>>) => {
   const categoryElement = categoryRefs.current[categoryId];
 
-  if (!categoryElement) {
-    return;
-  }
+  if (!categoryElement) return;
 
   const elementPosition = categoryElement.getBoundingClientRect().top;
   const headerHeight = 110;
@@ -16,9 +14,7 @@ export const scrollToCategory = (categoryId: string, categoryRefs: React.Mutable
 };
 
 export const scrollToCategoryBadge = (categoryId: string, containerRef: React.RefObject<HTMLDivElement>) => {
-  if (!containerRef.current) {
-    return;
-  }
+  if (!containerRef.current) return;
 
   const badgeElement = containerRef.current.querySelector(`#categoryBadge_${categoryId}`) as HTMLElement | null;
   if (badgeElement) {

--- a/src/utils/CategoryTracking.ts
+++ b/src/utils/CategoryTracking.ts
@@ -1,14 +1,22 @@
-export const scrollToCategory = (categoryId: string, categoryRefs: React.MutableRefObject<Record<string, HTMLDivElement | null>>) => {
+export const scrollToCategory = (categoryId: string, categoryRefs: React.MutableRefObject<Record<string, HTMLDivElement | null>>, callback: () => void) => {
   const categoryElement = categoryRefs.current[categoryId];
-
   if (!categoryElement) return;
 
   const elementPosition = categoryElement.getBoundingClientRect().top;
   const headerHeight = 110;
-  const offsetPosition = elementPosition + window.scrollY - headerHeight;
+  const offset = elementPosition + window.scrollY - headerHeight;
+
+  const onScroll = () => {
+    if (Math.abs(window.scrollY - offset) < 2) {
+      window.removeEventListener('scroll', onScroll);
+      callback();
+    }
+  };
+
+  window.addEventListener('scroll', onScroll);
 
   window.scrollTo({
-    top: offsetPosition,
+    top: offset,
     behavior: 'smooth',
   });
 };

--- a/src/utils/CategoryTracking.ts
+++ b/src/utils/CategoryTracking.ts
@@ -3,7 +3,7 @@ export const scrollToCategory = (categoryId: string, categoryRefs: React.Mutable
   if (!categoryElement) return;
 
   const elementPosition = categoryElement.getBoundingClientRect().top;
-  const headerHeight = 110;
+  const headerHeight = 100;
   const offset = elementPosition + window.scrollY - headerHeight;
   const marginPixel = 2;
 

--- a/src/utils/CategoryTracking.ts
+++ b/src/utils/CategoryTracking.ts
@@ -5,9 +5,10 @@ export const scrollToCategory = (categoryId: string, categoryRefs: React.Mutable
   const elementPosition = categoryElement.getBoundingClientRect().top;
   const headerHeight = 110;
   const offset = elementPosition + window.scrollY - headerHeight;
+  const marginPixel = 2;
 
   const onScroll = () => {
-    if (Math.abs(window.scrollY - offset) < 2) {
+    if (Math.abs(window.scrollY - offset) < marginPixel) {
       window.removeEventListener('scroll', onScroll);
       callback();
     }

--- a/src/utils/CategoryTracking.ts
+++ b/src/utils/CategoryTracking.ts
@@ -16,7 +16,8 @@ export const scrollToCategory = (categoryId: string, categoryRefs: React.Mutable
 export const scrollToCategoryBadge = (categoryId: string, containerRef: React.RefObject<HTMLDivElement>) => {
   if (!containerRef.current) return;
 
-  const badgeElement = containerRef.current.querySelector(`#categoryBadge_${categoryId}`) as HTMLElement | null;
+  const escapedId = CSS.escape(`categoryBadge_${categoryId}`);
+  const badgeElement = containerRef.current.querySelector(`#${escapedId}`) as HTMLElement | null;
   if (badgeElement) {
     badgeElement.scrollIntoView({
       behavior: 'smooth',


### PR DESCRIPTION
## 📚 개요


https://github.com/user-attachments/assets/f89612a8-df0b-45da-8a5d-6b551cb3189a

- 외부 라이브러리를 사용하지 않고 카테고리 뱃지 관련한 디자인을 적용했습니다.
- ref를 통해 스크롤 하고자 하는 요소를 추적하였습니다.


## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

```js
  const isManualScrollRef = useRef(false);

  const handleCategoryClick = (categoryId: string) => {
    isManualScrollRef.current = true;

    setActiveCategory(categoryId);
    scrollToCategoryBadge(categoryId, containerRef);
    scrollToCategory(categoryId, categoryRefs);

    setTimeout(() => {
      isManualScrollRef.current = false;
    }, 500);
  };
```

- `setTimeOut` 함수를 통해 시간차를 두고 ` isManualScrollRef = false`하는 이유는 다음과 같습니다.
카테고리 뱃지가 selected 되는 경우는 2가지입니다.

1. 사용자가 해당 뱃지를 클릭했을 때 
2.  스크롤 이벤트를 통해 현재 보이는 카테고리와 같은 뱃지일 때

이때 문제가 생기는 부분이 2번입니다. 
다음 영상과 같이 인기메뉴 뱃지를 클릭했을 때, 초교급메뉴 뱃지가 잠깐 selected 되었다가 돌아온 모습을 보실 수 있습니다. 이를 해결하고자 스크롤이 충분히 다 이루어졌을 때 ` isManualScrollRef = false`를 해주어 초기화 시킵니다.

https://github.com/user-attachments/assets/59188aa5-8a04-4c8e-9ea7-cfcb704bdc71

더 좋은 방법이 있다면 제시해주세요!
