### PR TITLE
EDIT - 결제 확인 페이지 새로운 디자인 적용

### DIFF
--- a/src/components/admin/order/OrderStickyNavBar.tsx
+++ b/src/components/admin/order/OrderStickyNavBar.tsx
@@ -58,7 +58,7 @@ interface OrderStickyNavBarProps {
   useLeftArrow?: boolean;
   showNavBar: boolean;
   workspaceName: string;
-  tableNo?: string | null;
+  tableNo?: string | number | null;
   useShareButton?: boolean;
 }
 

--- a/src/components/user/order/OrderStatusBar.tsx
+++ b/src/components/user/order/OrderStatusBar.tsx
@@ -1,63 +1,51 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import AppLabel from '@components/common/label/AppLabel';
-import { colFlex, rowFlex } from '@styles/flexStyles';
+import { rowFlex } from '@styles/flexStyles';
 import { OrderStatus } from '@@types/index';
+import { Color } from '@resources/colors';
 
 interface OrderStatusBarProps {
   status: OrderStatus;
 }
 
 const Container = styled.div`
-  margin-top: 20px;
-  padding: 0 20px;
-  ${rowFlex({ justify: 'space-between', align: 'center' })}
+  width: 100%;
+  ${rowFlex({ justify: 'space-between' })}
+`;
+
+const OrderStatusText = styled.div<{ active: boolean }>`
+  font-size: 13px;
+  font-weight: 500;
+  color: ${({ active }) => (active ? Color.BLACK : '#898989')};
 `;
 
 const CancelContainer = styled.div`
-  gap: 5px;
-  ${colFlex({ align: 'center' })}
+  width: 100%;
+  ${rowFlex({ justify: 'center' })};
 `;
 
-const CurrentStatusLabel = styled(AppLabel)`
-  font-weight: 600;
-  font-size: 15px;
-`;
-
-const OtherStatusLabel = styled(AppLabel)`
-  font-weight: 400;
+const CancelText = styled.div`
   font-size: 13px;
-  color: #6f6f6f;
+  font-weight: 500;
+  color: ${Color.KIO_ORANGE};
 `;
 
 function OrderStatusBar({ status }: OrderStatusBarProps) {
   if (status === OrderStatus.CANCELLED) {
     return (
-      <CancelContainer className={'cancel-container'}>
-        <CurrentStatusLabel className={'cancel-status-label'}>주문 취소</CurrentStatusLabel>
+      <CancelContainer>
+        <CancelText>취소된 주문입니다.</CancelText>
       </CancelContainer>
     );
   }
 
   return (
     <Container>
-      {status === OrderStatus.NOT_PAID ? (
-        <CurrentStatusLabel className={'current-status-label'}>결제 확인 중</CurrentStatusLabel>
-      ) : (
-        <OtherStatusLabel className={'other-status-label'}>결제 확인 중</OtherStatusLabel>
-      )}
-      {'· · ·'}
-      {status === OrderStatus.PAID ? (
-        <CurrentStatusLabel className={'current-status-label'}>조리중</CurrentStatusLabel>
-      ) : (
-        <OtherStatusLabel className={'other-status-label'}>조리중</OtherStatusLabel>
-      )}
-      {'· · ·'}
-      {status === OrderStatus.SERVED ? (
-        <CurrentStatusLabel className={'current-status-label'}>서빙 완료</CurrentStatusLabel>
-      ) : (
-        <OtherStatusLabel className={'other-status-label'}>서빙 완료</OtherStatusLabel>
-      )}
+      <OrderStatusText active={status === OrderStatus.NOT_PAID}>결제대기</OrderStatusText>
+      <OrderStatusText active={false}> {'· · ·'}</OrderStatusText>
+      <OrderStatusText active={status === OrderStatus.PAID}>조리중</OrderStatusText>
+      <OrderStatusText active={false}> {'· · ·'}</OrderStatusText>
+      <OrderStatusText active={status === OrderStatus.SERVED}>서빙완료</OrderStatusText>
     </Container>
   );
 }

--- a/src/hooks/useRefresh.tsx
+++ b/src/hooks/useRefresh.tsx
@@ -1,0 +1,12 @@
+function useRefresh() {
+  const allowPullToRefresh = () => {
+    const body = document.querySelector('body');
+    if (body) {
+      body.style.overscrollBehaviorY = 'auto';
+    }
+  };
+
+  return { allowPullToRefresh };
+}
+
+export default useRefresh;

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -1,59 +1,108 @@
 import React, { useEffect, useState } from 'react';
 import useOrder from '@hooks/user/useOrder';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { orderBasketAtom, userOrderAtom } from '@recoils/atoms';
+import { orderBasketAtom, userOrderAtom, userWorkspaceAtom } from '@recoils/atoms';
 import { useSearchParams } from 'react-router-dom';
 import styled from '@emotion/styled';
-import AppLabel from '@components/common/label/AppLabel';
-import OrderStatusBar from '@components/user/order/OrderStatusBar';
-import ReloadSvg from '@resources/svg/ReloadSvg';
 import useWorkspace from '@hooks/user/useWorkspace';
-import AppButton from '@components/common/button/AppButton';
 import { colFlex, rowFlex } from '@styles/flexStyles';
-import { OrderStatus } from '@@types/index';
-import OrderButton from '@components/user/order/OrderButton';
 import { Color } from '@resources/colors';
+import OrderStickyNavBar from '@components/admin/order/OrderStickyNavBar';
+import OrderStatusBar from '@components/user/order/OrderStatusBar';
 
 const Container = styled.div`
-  width: 100vw;
-  min-height: 100vh;
-  padding: 60px 0 80px;
-`;
-
-const Header = styled.div`
-  background: ${Color.WHITE};
-  position: sticky;
-  top: 0;
-  width: 100vw;
-  padding: 25px;
-  box-sizing: border-box;
-  z-index: 100;
-  ${rowFlex({ justify: 'space-between', align: 'center' })}
+  width: 100%;
+  height: 100%;
 `;
 
 const SubContainer = styled.div`
-  gap: 10px;
+  margin-top: 45px;
+  gap: 20px;
+  border-top: 10px solid ${Color.LIGHT_GREY};
+  padding-top: 12px;
   ${colFlex({ justify: 'center', align: 'center' })}
+`;
+
+const SubTitleContainer = styled.div`
+  width: 100%;
+  padding: 0 40px;
+  box-sizing: border-box;
+  gap: 10px;
+  ${colFlex()};
+`;
+
+const SubTitle = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const ContentContainer = styled.div`
+  width: 100%;
+  gap: 6px;
+  ${colFlex({ align: 'center' })}
+`;
+
+const ContentTitleContainer = styled.div`
+  width: 300px;
+  ${rowFlex({ justify: 'space-between' })}
+`;
+
+const ContentTitle = styled.div`
+  font-size: 13px;
+  font-weight: 500;
 `;
 
 const ContentBox = styled.div`
   width: 100%;
-  padding: 20px;
-  background: #${Color.HEAVY_GREY};
+  padding: 20px 40px;
   box-sizing: border-box;
-  gap: 4px;
+  background: ${Color.LIGHT_GREY};
   ${colFlex()}
 `;
 
-const ContentTitleLabel = styled(AppLabel)`
-  font-weight: bold;
-  margin-bottom: 3px;
+const ContentText = styled.div`
+  font-size: 13px;
+  font-weight: 500;
+  color: #898989;
 `;
 
-const ProductContainer = styled.div`
-  gap: 4px;
-  padding: 10px 0;
+const OrderProductContainer = styled.div`
+  width: 100%;
+  gap: 10px;
   ${colFlex()}
+`;
+
+const OrderProductRow = styled.div`
+  width: 100%;
+  ${rowFlex({ justify: 'space-between' })}
+`;
+
+const OrderProductText = styled.div`
+  font-size: 13px;
+  font-weight: 500;
+`;
+
+const AccountCopyButton = styled.button`
+  background: transparent;
+  border: 1px solid ${Color.GREY};
+  border-radius: 40px;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 0 10px;
+`;
+
+const DescriptionContainer = styled.div`
+  padding: 20px 0;
+  width: 320px;
+  ${colFlex({ justify: 'center', align: 'center' })};
+`;
+
+const Description = styled.div`
+  font-size: 13px;
+  font-weight: 500;
+  text-align: center;
+  color: #898989;
+  white-space: pre-wrap;
 `;
 
 function OrderComplete() {
@@ -62,10 +111,11 @@ function OrderComplete() {
   const orderId = searchParams.get('orderId');
   const workspaceId = searchParams.get('workspaceId');
 
-  const { fetchWorkspaceAccount } = useWorkspace();
+  const { fetchWorkspaceAccount, fetchWorkspace } = useWorkspace();
   const { fetchOrder } = useOrder();
   const setOrderBasket = useSetRecoilState(orderBasketAtom);
   const order = useRecoilValue(userOrderAtom);
+  const workspace = useRecoilValue(userWorkspaceAtom);
 
   const dateConverter = (date: Date) => {
     const isAm = date.getHours() < 12;
@@ -93,69 +143,71 @@ function OrderComplete() {
   useEffect(() => {
     resetRecoilState();
     fetchOrder(orderId);
+    fetchWorkspace(workspaceId);
     getAccountInfo();
   }, []);
 
   return (
     <Container className={'order-complete-container'}>
-      <Header className={'order-complete-header'}>
-        <AppLabel>주문 내역</AppLabel>
-        <ReloadSvg onClick={() => window.location.reload()}>새로고침</ReloadSvg>
-      </Header>
+      <OrderStickyNavBar showNavBar={true} workspaceName={workspace.name} tableNo={order.tableNumber} useShareButton={false} />
       <SubContainer className={'order-complete-sub-container'}>
-        <ContentBox className={'order-complete-content-box'}>
-          <ContentTitleLabel size={17} className={'order-complete-content-title-label'}>
-            주문 번호: {orderId}번
-          </ContentTitleLabel>
-          <AppLabel size={13}>주문 일시: {dateConverter(new Date(order.createdAt))}</AppLabel>
-          <AppLabel size={13}>입금자명: {order?.customerName}</AppLabel>
-        </ContentBox>
-        <ContentBox className={'order-complete-content-box'}>
-          <ContentTitleLabel size={17} className={'order-complete-content-title-label'}>
-            주문 상태
-          </ContentTitleLabel>
-          <OrderStatusBar status={order.status} />
-        </ContentBox>
-        <ContentBox className={'order-complete-content-box'}>
-          <ContentTitleLabel size={17} className={'order-complete-content-title-label'}>
-            주문 상품
-          </ContentTitleLabel>
-          {order?.orderProducts.map((orderProduct) => (
-            <ProductContainer key={orderProduct.id} className={'order-complete-product-container'}>
-              <AppLabel size={13} style={{ fontWeight: 'bold' }}>
-                {orderProduct.productName} · {orderProduct.quantity}개
-              </AppLabel>
-              <AppLabel size={13}>{orderProduct.totalPrice.toLocaleString()}원</AppLabel>
-            </ProductContainer>
-          ))}
-        </ContentBox>
-        <ContentBox className={'order-complete-content-box'}>
-          <ContentTitleLabel size={17} className={'order-complete-content-title-label'}>
-            총 결제 금액
-          </ContentTitleLabel>
-          <AppLabel size={13}>{order.totalPrice.toLocaleString()}원</AppLabel>
-        </ContentBox>
-        {order.status === OrderStatus.NOT_PAID && (
-          <ContentBox className={'order-complete-content-box'}>
-            <ContentTitleLabel size={17} className={'order-complete-content-title-label'}>
-              결제 계좌 정보
-            </ContentTitleLabel>
-            <AppLabel size={13}>{accountInfo}</AppLabel>
-            <AppButton onClick={copyAccountInfo}>복사하기</AppButton>
+        <SubTitleContainer className={'order-complete-sub-title-container'}>
+          <SubTitle>주문내역</SubTitle>
+        </SubTitleContainer>
+        <ContentContainer>
+          <ContentTitleContainer>
+            <ContentTitle>주문 정보</ContentTitle>
+          </ContentTitleContainer>
+          <ContentBox>
+            <ContentText>주문일시 | {dateConverter(new Date(order.createdAt))}</ContentText>
+            <ContentText>주문번호 | {order.id}</ContentText>
+            <ContentText>입금자명 | {order.customerName}</ContentText>
           </ContentBox>
-        )}
+
+          <ContentTitleContainer>
+            <ContentTitle>주문 상태</ContentTitle>
+          </ContentTitleContainer>
+          <ContentBox>
+            <OrderStatusBar status={order.status} />
+          </ContentBox>
+
+          <ContentTitleContainer>
+            <ContentTitle>상품 정보</ContentTitle>
+          </ContentTitleContainer>
+          <ContentBox>
+            <OrderProductContainer>
+              {order.orderProducts.map((orderProduct) => (
+                <OrderProductRow key={orderProduct.id}>
+                  <OrderProductText>
+                    {orderProduct.productName} · {orderProduct.quantity}개
+                  </OrderProductText>
+                  <OrderProductText>{orderProduct.totalPrice.toLocaleString()}원</OrderProductText>
+                </OrderProductRow>
+              ))}
+            </OrderProductContainer>
+          </ContentBox>
+          <ContentBox>
+            <OrderProductContainer>
+              <OrderProductRow key={order.id}>
+                <OrderProductText>상품 합계</OrderProductText>
+                <OrderProductText>{order.totalPrice.toLocaleString()}원</OrderProductText>
+              </OrderProductRow>
+            </OrderProductContainer>
+          </ContentBox>
+
+          <ContentTitleContainer>
+            <ContentTitle>결제 계좌 정보</ContentTitle>
+            <AccountCopyButton onClick={copyAccountInfo}>계좌 복사하기</AccountCopyButton>
+          </ContentTitleContainer>
+          <ContentBox>
+            <ContentText>{accountInfo}</ContentText>
+          </ContentBox>
+
+          <DescriptionContainer>
+            <Description>{'결제가 원활하게 진행되지 않았을 경우,\n상단의 계좌 정보를 통해 직접 계좌이체를 부탁드립니다.'}</Description>
+          </DescriptionContainer>
+        </ContentContainer>
       </SubContainer>
-      {order.status !== OrderStatus.CANCELLED && (
-        <OrderButton
-          showButton={true}
-          buttonLabel={'주문내역 링크 복사'}
-          onClick={() => {
-            navigator.clipboard.writeText(window.location.href).then(() => {
-              alert('주문내역 링크가 복사되었습니다.\n인터넷 브라우저에 붙여넣기하여 주문내역 확인이 가능합니다.');
-            });
-          }}
-        />
-      )}
     </Container>
   );
 }

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import useOrder from '@hooks/user/useOrder';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { orderBasketAtom, userOrderAtom, userWorkspaceAtom } from '@recoils/atoms';
 import { useSearchParams } from 'react-router-dom';
 import styled from '@emotion/styled';
@@ -115,7 +115,7 @@ function OrderComplete() {
   const { fetchWorkspaceAccount, fetchWorkspace } = useWorkspace();
   const { fetchOrder } = useOrder();
   const { allowPullToRefresh } = useRefresh();
-  const setOrderBasket = useSetRecoilState(orderBasketAtom);
+  const resetOrderBasket = useResetRecoilState(orderBasketAtom);
   const order = useRecoilValue(userOrderAtom);
   const workspace = useRecoilValue(userWorkspaceAtom);
 
@@ -125,10 +125,6 @@ function OrderComplete() {
     const hour = isAm ? date.getHours() : date.getHours() - 12;
 
     return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ${ampm} ${hour}시 ${date.getMinutes()}분`;
-  };
-
-  const resetRecoilState = () => {
-    setOrderBasket([]);
   };
 
   const getAccountInfo = async () => {
@@ -143,7 +139,7 @@ function OrderComplete() {
   };
 
   useEffect(() => {
-    resetRecoilState();
+    resetOrderBasket();
     fetchOrder(orderId);
     fetchWorkspace(workspaceId);
     allowPullToRefresh();

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -9,6 +9,7 @@ import { colFlex, rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
 import OrderStickyNavBar from '@components/admin/order/OrderStickyNavBar';
 import OrderStatusBar from '@components/user/order/OrderStatusBar';
+import useRefresh from '@hooks/useRefresh';
 
 const Container = styled.div`
   width: 100%;
@@ -113,6 +114,7 @@ function OrderComplete() {
 
   const { fetchWorkspaceAccount, fetchWorkspace } = useWorkspace();
   const { fetchOrder } = useOrder();
+  const { allowPullToRefresh } = useRefresh();
   const setOrderBasket = useSetRecoilState(orderBasketAtom);
   const order = useRecoilValue(userOrderAtom);
   const workspace = useRecoilValue(userWorkspaceAtom);
@@ -144,6 +146,7 @@ function OrderComplete() {
     resetRecoilState();
     fetchOrder(orderId);
     fetchWorkspace(workspaceId);
+    allowPullToRefresh();
     getAccountInfo();
   }, []);
 


### PR DESCRIPTION
## 📚 개요

- 결제 확인 페이지에 새로운 디자인을 적용했습니다.
- 다만 현재 디자인 문서상에서 버튼의 기능은 좀 더 기획이 필요하다고 판단하여 구현하지 않았습니다.
- 계좌정보도 백엔드 및 프론트엔드 추가 구현이 필요한 부분이 있어서 현재 디자인과는 다르게 구현되어있습니다. (기능상으로는 같습니다.) 계좌 정보 등록 기능 부분을 개선하고 나서 이 부분을 수정할 예정입니다.
- 또한 이 페이지 한정으로 pull to refresh를 허용했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

주문 확인 화면
![image](https://github.com/user-attachments/assets/d153689a-3ee5-48dc-9f84-4a3e342db25b)

주문 취소 시 화면
![image](https://github.com/user-attachments/assets/8813b23b-6b5b-4628-aaf5-1343bbd48366)

