### PR TITLE
EDIT - 주문 확인 페이지 수정 및 새로운 account 타입 적용

### DIFF
--- a/src/components/admin/order/OrderPayNavBar.tsx
+++ b/src/components/admin/order/OrderPayNavBar.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
 `;
 
 const CategoryLink = styled.div<{ isSelected: boolean }>`
-  width: 50%;
+  width: 100%;
   padding: 10px 10px;
   border-bottom: ${({ isSelected }) => (isSelected ? '3px solid black' : '3px solid transparent')};
   font-weight: ${({ isSelected }) => (isSelected ? '600' : '')};
@@ -24,16 +24,19 @@ const CategoryLink = styled.div<{ isSelected: boolean }>`
 `;
 
 interface OrderPayNavBarProps {
+  isTossAvailable: boolean;
   isTossPay: boolean;
   setIsTossPay: (value: boolean) => void;
 }
 
-function OrderPayNavBar({ isTossPay, setIsTossPay }: OrderPayNavBarProps) {
+function OrderPayNavBar({ isTossAvailable, isTossPay, setIsTossPay }: OrderPayNavBarProps) {
   return (
     <Container>
-      <CategoryLink isSelected={isTossPay} onClick={() => setIsTossPay(true)}>
-        토스결제
-      </CategoryLink>
+      {isTossAvailable && (
+        <CategoryLink isSelected={isTossPay} onClick={() => setIsTossPay(true)}>
+          토스결제
+        </CategoryLink>
+      )}
       <CategoryLink isSelected={!isTossPay} onClick={() => setIsTossPay(false)}>
         계좌결제
       </CategoryLink>

--- a/src/components/admin/order/OrderStickyNavBar.tsx
+++ b/src/components/admin/order/OrderStickyNavBar.tsx
@@ -73,15 +73,10 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
       return;
     }
 
-    try {
-      await navigator.share({
-        title: workspaceName,
-        text: `키오스쿨에서 같이 주문해요!!`,
-        url: window.location.href,
-      });
-    } catch (error) {
-      alert(`공유 실패: ${error}`);
-    }
+    await navigator.share({
+      title: workspaceName,
+      url: window.location.href,
+    });
   };
 
   return (

--- a/src/components/user/order/OrderAccountInfo.tsx
+++ b/src/components/user/order/OrderAccountInfo.tsx
@@ -71,6 +71,13 @@ function OrderAccountInfo() {
     setAccountInfo(account);
   };
 
+  const copyAccountInfo = () => {
+    const bankName = accountInfo.bank.name;
+    const accountNumber = accountInfo.accountNumber;
+
+    navigator.clipboard.writeText(`${bankName} ${accountNumber}`);
+  };
+
   useEffect(() => {
     getAccountInfo();
   }, []);
@@ -79,7 +86,7 @@ function OrderAccountInfo() {
     <Container>
       <TitleContainer>
         <AppLabel size={15}>계좌 정보</AppLabel>
-        <CopyButton>계좌 복사하기</CopyButton>
+        <CopyButton onClick={copyAccountInfo}>계좌 복사하기</CopyButton>
       </TitleContainer>
       <AccountInfo>
         <InfoRow>

--- a/src/components/user/order/OrderAccountInfo.tsx
+++ b/src/components/user/order/OrderAccountInfo.tsx
@@ -75,7 +75,9 @@ function OrderAccountInfo() {
     const bankName = accountInfo.bank.name;
     const accountNumber = accountInfo.accountNumber;
 
-    navigator.clipboard.writeText(`${bankName} ${accountNumber}`);
+    navigator.clipboard.writeText(`${bankName} ${accountNumber}`).then(() => {
+      alert('계좌 정보가 복사되었습니다.');
+    });
   };
 
   useEffect(() => {

--- a/src/components/user/order/OrderAccountInfo.tsx
+++ b/src/components/user/order/OrderAccountInfo.tsx
@@ -72,8 +72,8 @@ function OrderAccountInfo() {
   };
 
   const copyAccountInfo = () => {
-    const bankName = accountInfo.bank.name;
-    const accountNumber = accountInfo.accountNumber;
+    const bankName = accountInfo?.bank?.name;
+    const accountNumber = accountInfo?.accountNumber;
 
     navigator.clipboard.writeText(`${bankName} ${accountNumber}`).then(() => {
       alert('계좌 정보가 복사되었습니다.');

--- a/src/components/user/order/OrderAccountInfo.tsx
+++ b/src/components/user/order/OrderAccountInfo.tsx
@@ -94,7 +94,7 @@ function OrderAccountInfo() {
         <InfoRow>
           <Key>금융기관</Key>
           <Divider>|</Divider>
-          <Value>{accountInfo.bank.name}</Value>
+          <Value>{accountInfo?.bank?.name}</Value>
         </InfoRow>
         <InfoRow>
           <Key>계좌번호</Key>

--- a/src/components/user/order/OrderAccountInfo.tsx
+++ b/src/components/user/order/OrderAccountInfo.tsx
@@ -2,7 +2,11 @@ import AppLabel from '@components/common/label/AppLabel';
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
-import React from 'react';
+import React, { useEffect } from 'react';
+import useWorkspace from '@hooks/user/useWorkspace';
+import { useSearchParams } from 'react-router-dom';
+import { Account } from '@@types/index';
+import { defaultAccountValue } from '@@types/defaultValues';
 
 const Container = styled.div`
   width: 100%;
@@ -53,12 +57,23 @@ const Value = styled.div`
 
 const Divider = styled.span``;
 
-function OrderPayAccountInfo() {
-  const dummyAccountInfo = {
-    bankName: '국민은행',
-    accountNumber: '123-456-789',
-    depositor: '홍길동',
+function OrderAccountInfo() {
+  const [searchParams] = useSearchParams();
+  const workspaceId = searchParams.get('workspaceId');
+  const [accountInfo, setAccountInfo] = React.useState<Account>(defaultAccountValue);
+
+  const { fetchWorkspaceAccount } = useWorkspace();
+
+  const getAccountInfo = async () => {
+    const account = await fetchWorkspaceAccount(workspaceId);
+    if (!account) return;
+
+    setAccountInfo(account);
   };
+
+  useEffect(() => {
+    getAccountInfo();
+  }, []);
 
   return (
     <Container>
@@ -70,21 +85,21 @@ function OrderPayAccountInfo() {
         <InfoRow>
           <Key>금융기관</Key>
           <Divider>|</Divider>
-          <Value>{dummyAccountInfo.bankName}</Value>
+          <Value>{accountInfo.bank.name}</Value>
         </InfoRow>
         <InfoRow>
           <Key>계좌번호</Key>
           <Divider>|</Divider>
-          <Value>{dummyAccountInfo.accountNumber}</Value>
+          <Value>{accountInfo?.accountNumber}</Value>
         </InfoRow>
         <InfoRow>
           <Key>예금주명</Key>
           <Divider>|</Divider>
-          <Value>{dummyAccountInfo.depositor}</Value>
+          <Value>{accountInfo?.accountHolder}</Value>
         </InfoRow>
       </AccountInfo>
     </Container>
   );
 }
 
-export default OrderPayAccountInfo;
+export default OrderAccountInfo;

--- a/src/components/user/order/OrderAccountInfo.tsx
+++ b/src/components/user/order/OrderAccountInfo.tsx
@@ -2,7 +2,7 @@ import AppLabel from '@components/common/label/AppLabel';
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import useWorkspace from '@hooks/user/useWorkspace';
 import { useSearchParams } from 'react-router-dom';
 import { Account } from '@@types/index';
@@ -60,7 +60,7 @@ const Divider = styled.span``;
 function OrderAccountInfo() {
   const [searchParams] = useSearchParams();
   const workspaceId = searchParams.get('workspaceId');
-  const [accountInfo, setAccountInfo] = React.useState<Account>(defaultAccountValue);
+  const [accountInfo, setAccountInfo] = useState<Account>(defaultAccountValue);
 
   const { fetchWorkspaceAccount } = useWorkspace();
 

--- a/src/components/user/order/OrderButton.tsx
+++ b/src/components/user/order/OrderButton.tsx
@@ -31,7 +31,7 @@ function OrderButton({ showButton, buttonLabel, onClick }: OrderButtonProps) {
   return (
     <Container className={'order-button-container'}>
       <OrderButtonSubContainer className={'order-button-sub-container'}>
-        <AppButton size={290} onClick={onClick}>
+        <AppButton size={290} onClick={onClick} style={{ fontWeight: 'bold' }}>
           {buttonLabel}
         </AppButton>
       </OrderButtonSubContainer>

--- a/src/components/user/order/OrderPayAccountInfo.tsx
+++ b/src/components/user/order/OrderPayAccountInfo.tsx
@@ -54,45 +54,15 @@ const Value = styled.div`
 
 const Divider = styled.span``;
 
-const Description = styled.div`
-  width: 100%;
-  font-size: 13px;
-  font-weight: 500;
-  color: #898989;
-  text-align: center;
-  box-sizing: border-box;
-  background: ${Color.LIGHT_GREY};
-  padding: 10px 40px;
-  word-break: keep-all;
-  ${colFlex({ justify: 'center', align: 'center' })}
-`;
-
-const dummyAccountInfo = {
-  bankName: '국민은행',
-  accountNumber: '620002-04-112345',
-  depositor: '김지인',
-};
-
-interface OrderPayAccountInfoProps {
-  isTossPay: boolean;
-}
-
-function OrderPayAccountInfo({ isTossPay }: OrderPayAccountInfoProps) {
-  if (isTossPay) {
-    return (
-      <Description>
-        입력하신 입금자명과 실제 입금자명이 일치하지 않을 경우 결제 확인이 어려울 수 있습니다. 아래 버튼을 클릭하시면 주문이 완료되며, 토스 송금 페이지로
-        이동합니다.
-      </Description>
-    );
-  }
+function OrderPayAccountInfo() {
+  const dummyAccountInfo = {
+    bankName: '국민은행',
+    accountNumber: '123-456-789',
+    depositor: '홍길동',
+  };
 
   return (
     <Container>
-      <Description>
-        입력하신 입금자명과 실제 입금자명이 일치하지 않을 경우 결제 확인이 어려울 수 있습니다. 아래 버튼을 클릭하시면 주문이 완료되며, 주문하신 금액에 맞게
-        송금해주시면 됩니다.
-      </Description>
       <TitleContainer>
         <AppLabel size={15}>계좌 정보</AppLabel>
         <CopyButton>계좌 복사하기</CopyButton>

--- a/src/components/user/order/OrderPayAccountInfo.tsx
+++ b/src/components/user/order/OrderPayAccountInfo.tsx
@@ -20,10 +20,10 @@ const AccountInfo = styled.div`
   font-size: 13px;
   font-weight: 500;
   color: #898989;
-  padding: 10px 40px;
+  padding: 10px 20px;
   box-sizing: border-box;
   background: ${Color.LIGHT_GREY};
-  ${colFlex({ justify: 'center', align: 'center' })}
+  ${colFlex({ justify: 'center' })}
 `;
 
 const CopyButton = styled.button`
@@ -43,7 +43,6 @@ const InfoRow = styled.div`
 `;
 
 const Key = styled.div`
-  width: 90px;
   ${rowFlex({ justify: 'end', align: 'center' })}
 `;
 
@@ -69,7 +68,7 @@ function OrderPayAccountInfo() {
       </TitleContainer>
       <AccountInfo>
         <InfoRow>
-          <Key>은행명</Key>
+          <Key>금융기관</Key>
           <Divider>|</Divider>
           <Value>{dummyAccountInfo.bankName}</Value>
         </InfoRow>
@@ -79,7 +78,7 @@ function OrderPayAccountInfo() {
           <Value>{dummyAccountInfo.accountNumber}</Value>
         </InfoRow>
         <InfoRow>
-          <Key>예금주</Key>
+          <Key>예금주명</Key>
           <Divider>|</Divider>
           <Value>{dummyAccountInfo.depositor}</Value>
         </InfoRow>

--- a/src/components/user/order/OrderPayDescription.tsx
+++ b/src/components/user/order/OrderPayDescription.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { colFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
-import OrderPayAccountInfo from '@components/user/order/OrderPayAccountInfo';
+import OrderAccountInfo from '@components/user/order/OrderAccountInfo';
 
 const Container = styled.div`
   width: 100%;
@@ -43,7 +43,7 @@ function OrderPayDescription({ isTossPay }: OrderPayDescriptionProps) {
         입력하신 입금자명과 실제 입금자명이 일치하지 않을 경우 결제 확인이 어려울 수 있습니다. 아래 버튼을 클릭하시면 주문이 완료되며, 주문하신 금액에 맞게
         송금해주시면 됩니다.
       </Description>
-      <OrderPayAccountInfo />
+      <OrderAccountInfo />
     </Container>
   );
 }

--- a/src/components/user/order/OrderPayDescription.tsx
+++ b/src/components/user/order/OrderPayDescription.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { colFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
+import OrderPayAccountInfo from '@components/user/order/OrderPayAccountInfo';
+
+const Container = styled.div`
+  width: 100%;
+  gap: 5px;
+  ${colFlex({ justify: 'center', align: 'center' })}
+`;
+
+const Description = styled.div`
+  width: 100%;
+  font-size: 13px;
+  font-weight: 500;
+  color: #898989;
+  text-align: center;
+  box-sizing: border-box;
+  background: ${Color.LIGHT_GREY};
+  padding: 10px 40px;
+  word-break: keep-all;
+  ${colFlex({ justify: 'center', align: 'center' })}
+`;
+
+interface OrderPayDescriptionProps {
+  isTossPay: boolean;
+}
+
+function OrderPayDescription({ isTossPay }: OrderPayDescriptionProps) {
+  if (isTossPay) {
+    return (
+      <Description>
+        입력하신 입금자명과 실제 입금자명이 일치하지 않을 경우 결제 확인이 어려울 수 있습니다. 아래 버튼을 클릭하시면 주문이 완료되며, 토스 송금 페이지로
+        이동합니다.
+      </Description>
+    );
+  }
+
+  return (
+    <Container>
+      <Description>
+        입력하신 입금자명과 실제 입금자명이 일치하지 않을 경우 결제 확인이 어려울 수 있습니다. 아래 버튼을 클릭하시면 주문이 완료되며, 주문하신 금액에 맞게
+        송금해주시면 됩니다.
+      </Description>
+      <OrderPayAccountInfo />
+    </Container>
+  );
+}
+
+export default OrderPayDescription;

--- a/src/components/user/order/OrderPayDescription.tsx
+++ b/src/components/user/order/OrderPayDescription.tsx
@@ -18,7 +18,7 @@ const Description = styled.div`
   text-align: center;
   box-sizing: border-box;
   background: ${Color.LIGHT_GREY};
-  padding: 10px 40px;
+  padding: 10px 30px;
   word-break: keep-all;
   ${colFlex({ justify: 'center', align: 'center' })}
 `;

--- a/src/hooks/user/useWorkspace.tsx
+++ b/src/hooks/user/useWorkspace.tsx
@@ -1,5 +1,5 @@
 import useApi from '@hooks/useApi';
-import { Workspace } from '@@types/index';
+import { Account, Workspace } from '@@types/index';
 import { userWorkspaceAtom } from '@recoils/atoms';
 import { useSetRecoilState } from 'recoil';
 
@@ -18,7 +18,7 @@ function useWorkspace() {
   const fetchWorkspaceAccount = async (workspaceId: string | undefined | null) => {
     if (!workspaceId) return;
 
-    return userApi.get<string>('/workspace/account', { params: { workspaceId } }).then((res) => {
+    return userApi.get<Account>('/workspace/account', { params: { workspaceId } }).then((res) => {
       return res.data;
     });
   };

--- a/src/pages/user/order/Order.tsx
+++ b/src/pages/user/order/Order.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { createSearchParams, useNavigate, useSearchParams } from 'react-router-dom';
 import styled from '@emotion/styled';
-import AppLabel from '@components/common/label/AppLabel';
 import CategoryBadgesContainer from '@components/user/order/CategoryBadgesContainer';
 import useWorkspace from '@hooks/user/useWorkspace';
 import { categoriesAtom, orderBasketAtom, userWorkspaceAtom } from '@recoils/atoms';
@@ -34,8 +33,20 @@ const StickyHeader = styled.div`
 const Header = styled.div`
   width: 100%;
   height: 120px;
+  word-break: keep-all;
   ${colFlex({ justify: 'center', align: 'center' })}
   gap: 7px;
+`;
+
+const Title = styled.div`
+  font-size: 25px;
+  font-weight: 600;
+`;
+
+const Description = styled.div`
+  font-size: 18px;
+  color: ${Color.GREY};
+  text-align: center;
 `;
 
 function Order() {
@@ -88,12 +99,8 @@ function Order() {
       <OrderImageSlider images={workspace.images} />
 
       <Header ref={headerRef}>
-        <AppLabel color={Color.BLACK} size={25} style={{ fontWeight: '600' }}>
-          {workspace.name}
-        </AppLabel>
-        <AppLabel size={'small'} color={Color.GREY}>
-          {workspace.description}
-        </AppLabel>
+        <Title>{workspace.name}</Title>
+        <Description>{workspace.description}</Description>
       </Header>
 
       <OrderStickyNavBar showNavBar={showNavBar} workspaceName={workspace.name} />

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -127,7 +127,7 @@ function OrderComplete() {
 
   return (
     <Container className={'order-complete-container'}>
-      <OrderStickyNavBar showNavBar={true} workspaceName={workspace.name} tableNo={order.tableNumber} useShareButton={true} />
+      <OrderStickyNavBar showNavBar={true} workspaceName={workspace.name} tableNo={order.tableNumber} useShareButton={true} useLeftArrow={false} />
       <SubContainer className={'order-complete-sub-container'}>
         <SubTitleContainer className={'order-complete-sub-title-container'}>
           <SubTitle>주문내역</SubTitle>

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import useOrder from '@hooks/user/useOrder';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { orderBasketAtom, userOrderAtom, userWorkspaceAtom } from '@recoils/atoms';
@@ -10,6 +10,7 @@ import { Color } from '@resources/colors';
 import OrderStickyNavBar from '@components/admin/order/OrderStickyNavBar';
 import OrderStatusBar from '@components/user/order/OrderStatusBar';
 import useRefresh from '@hooks/useRefresh';
+import OrderAccountInfo from '@components/user/order/OrderAccountInfo';
 
 const Container = styled.div`
   width: 100%;
@@ -83,15 +84,6 @@ const OrderProductText = styled.div`
   font-weight: 500;
 `;
 
-const AccountCopyButton = styled.button`
-  background: transparent;
-  border: 1px solid ${Color.GREY};
-  border-radius: 40px;
-  font-size: 13px;
-  font-weight: 500;
-  padding: 0 10px;
-`;
-
 const DescriptionContainer = styled.div`
   padding: 20px 0;
   width: 320px;
@@ -107,12 +99,11 @@ const Description = styled.div`
 `;
 
 function OrderComplete() {
-  const [accountInfo, setAccountInfo] = useState<string>();
   const [searchParams] = useSearchParams();
   const orderId = searchParams.get('orderId');
   const workspaceId = searchParams.get('workspaceId');
 
-  const { fetchWorkspaceAccount, fetchWorkspace } = useWorkspace();
+  const { fetchWorkspace } = useWorkspace();
   const { fetchOrder } = useOrder();
   const { allowPullToRefresh } = useRefresh();
   const resetOrderBasket = useResetRecoilState(orderBasketAtom);
@@ -127,23 +118,11 @@ function OrderComplete() {
     return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ${ampm} ${hour}시 ${date.getMinutes()}분`;
   };
 
-  const getAccountInfo = async () => {
-    const rawAccountInfo = await fetchWorkspaceAccount(workspaceId);
-    setAccountInfo(rawAccountInfo);
-  };
-
-  const copyAccountInfo = () => {
-    navigator.clipboard.writeText(accountInfo!).then(() => {
-      alert('계좌 정보가 복사되었습니다.');
-    });
-  };
-
   useEffect(() => {
     resetOrderBasket();
     fetchOrder(orderId);
     fetchWorkspace(workspaceId);
     allowPullToRefresh();
-    getAccountInfo();
   }, []);
 
   return (
@@ -193,15 +172,7 @@ function OrderComplete() {
               </OrderProductRow>
             </OrderProductContainer>
           </ContentBox>
-
-          <ContentTitleContainer>
-            <ContentTitle>결제 계좌 정보</ContentTitle>
-            <AccountCopyButton onClick={copyAccountInfo}>계좌 복사하기</AccountCopyButton>
-          </ContentTitleContainer>
-          <ContentBox>
-            <ContentText>{accountInfo}</ContentText>
-          </ContentBox>
-
+          <OrderAccountInfo />
           <DescriptionContainer>
             <Description>{'결제가 원활하게 진행되지 않았을 경우,\n상단의 계좌 정보를 통해 직접 계좌이체를 부탁드립니다.'}</Description>
           </DescriptionContainer>

--- a/src/pages/user/order/OrderPay.tsx
+++ b/src/pages/user/order/OrderPay.tsx
@@ -127,7 +127,11 @@ function OrderPay() {
           <OrderPayDescription isTossPay={isTossPay} />
         </DescriptionContainer>
       </SubContainer>
-      <OrderButton showButton={orderBasket.length > 0} buttonLabel={isTossPay ? 'Toss로 주문하기' : `주문하기`} onClick={payOrder} />
+      <OrderButton
+        showButton={orderBasket.length > 0}
+        buttonLabel={`${totalAmount.toLocaleString()}원 · ${isTossPay ? 'Toss로' : '계좌로'} 결제하기`}
+        onClick={payOrder}
+      />
     </Container>
   );
 }

--- a/src/pages/user/order/OrderPay.tsx
+++ b/src/pages/user/order/OrderPay.tsx
@@ -59,7 +59,9 @@ function OrderPay() {
   const workspaceId = searchParams.get('workspaceId');
   const tableNo = searchParams.get('tableNo');
 
-  const tossAccountUrl = workspace.owner.accountUrl;
+  const account = workspace.owner.account;
+  const tossAccountUrl = account?.tossAccountUrl;
+  const isTossAvailable = !!tossAccountUrl;
 
   useEffect(() => {
     if (orderBasket.length === 0) {
@@ -107,7 +109,7 @@ function OrderPay() {
     <Container className={'order-pay-container'}>
       <OrderStickyNavBar showNavBar={true} workspaceName={workspace.name} tableNo={tableNo} useShareButton={false} />
       <SubContainer className={'order-pay-sub-container'}>
-        <OrderPayNavBar isTossPay={isTossPay} setIsTossPay={setIsTossPay} />
+        <OrderPayNavBar isTossAvailable={isTossAvailable} isTossPay={isTossPay} setIsTossPay={setIsTossPay} />
         <InputContainer>
           <Input type="text" placeholder={'입금자명을 입력해주세요.'} ref={customerNameRef} />
         </InputContainer>

--- a/src/pages/user/order/OrderPay.tsx
+++ b/src/pages/user/order/OrderPay.tsx
@@ -9,7 +9,7 @@ import { colFlex } from '@styles/flexStyles';
 import useOrder from '@hooks/user/useOrder';
 import OrderStickyNavBar from '@components/admin/order/OrderStickyNavBar';
 import OrderPayNavBar from '@components/admin/order/OrderPayNavBar';
-import OrderPayAccountInfo from '@components/user/order/OrderPayAccountInfo';
+import OrderPayDescription from '@components/user/order/OrderPayDescription';
 
 const Container = styled.div`
   width: 100%;
@@ -112,7 +112,7 @@ function OrderPay() {
           <Input type="text" placeholder={'입금자명을 입력해주세요.'} ref={customerNameRef} />
         </InputContainer>
         <DescriptionContainer>
-          <OrderPayAccountInfo isTossPay={isTossPay} />
+          <OrderPayDescription isTossPay={isTossPay} />
         </DescriptionContainer>
       </SubContainer>
       <OrderButton showButton={orderBasket.length > 0} buttonLabel={isTossPay ? 'Toss로 주문하기' : `주문하기`} onClick={payOrder} />

--- a/src/pages/user/order/OrderPay.tsx
+++ b/src/pages/user/order/OrderPay.tsx
@@ -87,6 +87,18 @@ function OrderPay() {
     });
   };
 
+  const createOrderAndNavigateToComplete = (customerName: string) => {
+    createOrder(workspaceId, tableNo, orderBasket, customerName).then((res) => {
+      navigate({
+        pathname: '/order-complete',
+        search: createSearchParams({
+          orderId: res.data.id.toString(),
+          workspaceId: workspaceId || '',
+        }).toString(),
+      });
+    });
+  };
+
   const payOrder = () => {
     const customerName = customerNameRef.current?.value;
 
@@ -100,9 +112,7 @@ function OrderPay() {
       return;
     }
 
-    /**
-     * TODO: 일반 결제 시 로직.
-     */
+    createOrderAndNavigateToComplete(customerName);
   };
 
   return (

--- a/src/types/defaultValues.ts
+++ b/src/types/defaultValues.ts
@@ -132,6 +132,7 @@ export const defaultAccountValue: Account = {
   bank: defaultBankValue,
   accountNumber: '',
   accountHolder: '',
+  tossAccountUrl: '',
   id: 0,
   createdAt: '',
   updatedAt: '',

--- a/src/types/defaultValues.ts
+++ b/src/types/defaultValues.ts
@@ -1,4 +1,6 @@
 import {
+  Account,
+  Bank,
   Order,
   OrderProduct,
   OrderProductBase,
@@ -118,10 +120,28 @@ export const defaultProductEditValue: ProductEdit = {
   },
 };
 
+export const defaultBankValue: Bank = {
+  name: '',
+  code: '',
+  id: 0,
+  createdAt: '',
+  updatedAt: '',
+};
+
+export const defaultAccountValue: Account = {
+  bank: defaultBankValue,
+  accountNumber: '',
+  accountHolder: '',
+  id: 0,
+  createdAt: '',
+  updatedAt: '',
+};
+
 export const defaultUserValue: User = {
   name: '',
   email: '',
   role: UserRole.ADMIN,
+  account: defaultAccountValue,
   accountUrl: '',
   id: 0,
   createdAt: '',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -132,7 +132,7 @@ export interface User {
   name: string;
   email: string;
   role: UserRole;
-  account: Account;
+  account: Account | null;
   accountUrl: string;
   id: number;
   createdAt: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -143,6 +143,7 @@ export interface Account {
   bank: Bank;
   accountNumber: string;
   accountHolder: string;
+  tossAccountUrl: string;
   id: number;
   createdAt: string;
   updatedAt: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -132,7 +132,25 @@ export interface User {
   name: string;
   email: string;
   role: UserRole;
+  account: Account;
   accountUrl: string;
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Account {
+  bank: Bank;
+  accountNumber: string;
+  accountHolder: string;
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Bank {
+  name: string;
+  code: string;
   id: number;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 📚 개요

- 더미로 구현되어 있던 부분들을 모두 구현했습니다.
- 주문 확인 페이지에서 토스 결제가 불가능 할 경우에 결제계좌만 가능하게끔 적용했습니다.
- 백엔드에 새로 적용된 account 타입 적용해서 계좌 정보를 보여주게끔 했습니다.
- 주문 버튼에 bold를 적용하고 텍스트를 수정했습니다.
- 주문 완료 화면에서 뒤로가기 버튼을 숨기고, 공유시 title을 삭제했습니다.

## 🕐 리뷰 예상 시간

> 10m

## ❗❗ 중요한 변경점(Option)

<img width="390" alt="image" src="https://github.com/user-attachments/assets/1fb4d925-6d18-45db-9581-f382137f42a2" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7903f55a-7e86-48d0-9036-f11f73c650cd" />

![image](https://github.com/user-attachments/assets/193c2125-ca8c-4052-9f28-77c7d6705d82)


![image](https://github.com/user-attachments/assets/3789e1be-7b0b-4af5-8282-8864e39923b4)
