### PR TITLE
ADD - orderNumber 필드 추가 및 적용

### DIFF
--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -83,7 +83,7 @@ function ServedOrderCard({ order }: OrderCardProps) {
                 {`테이블 ${order.tableNumber}`}
               </AppLabel>
               <AppLabel color={Color.BLACK} size={13}>
-                {`주문 번호 ${order.id}`}
+                {`주문 번호 ${order.orderNumber}`}
               </AppLabel>
             </TitleContainer>
             <OrderDetailModalButton order={order} />

--- a/src/components/admin/order/TableOrderCard.tsx
+++ b/src/components/admin/order/TableOrderCard.tsx
@@ -27,7 +27,7 @@ const OrderProductsContainer = styled.div`
   ${colFlex()}
 `;
 
-function TableOrderCard({ id, customerName, createdAt, orderProducts, totalPrice }: Order) {
+function TableOrderCard({ orderNumber, customerName, createdAt, orderProducts, totalPrice }: Order) {
   const dateConverter = (dateStr: string) => {
     const date = new Date(dateStr);
 
@@ -39,7 +39,7 @@ function TableOrderCard({ id, customerName, createdAt, orderProducts, totalPrice
 
   return (
     <Container className={'table-order-card-container'}>
-      <AppLabel size={16}>주문번호 {id}번</AppLabel>
+      <AppLabel size={16}>주문번호 {orderNumber}번</AppLabel>
       <Row className={'table-order-card-row'}>
         <AppLabel size={14}>입금자명: {customerName}</AppLabel>
         <AppLabel size={14}>{dateConverter(createdAt)}</AppLabel>

--- a/src/components/admin/order/ToggleOrderCard.tsx
+++ b/src/components/admin/order/ToggleOrderCard.tsx
@@ -62,7 +62,7 @@ function ToggleOrderCard({ order }: ToggleOrderCardProps) {
   return (
     <Container className={'toggle-order-card-container'}>
       <AppLabel size={18} style={{ fontWeight: 700 }}>
-        주문번호 {order.id}번
+        주문번호 {order.orderNumber}번
       </AppLabel>
       <ProductContainer className={'product-container'}>
         {isClosed ? (

--- a/src/components/admin/order/modal/OrderModalHeaderContents.tsx
+++ b/src/components/admin/order/modal/OrderModalHeaderContents.tsx
@@ -48,7 +48,7 @@ function OrderModalHeaderContents({ onClose, order }: OrderModalHeaderContentsPr
       </ModalHeaderTitle>
       <HeaderDetailContainer>
         <HeaderDetail>
-          <AppLabel color={Color.BLACK} size={17}>{`주문 번호  ${order.id}`}</AppLabel>
+          <AppLabel color={Color.BLACK} size={17}>{`주문 번호  ${order.orderNumber}`}</AppLabel>
           <AppLabel color={Color.BLACK} size={17}>{`${order.customerName} | ${formatDate(order.createdAt)}`}</AppLabel>
         </HeaderDetail>
         <AppLabel color={Color.KIO_ORANGE} size={20} style={{ fontWeight: 600 }}>

--- a/src/components/user/order/OrderTableHistoryCotent.tsx
+++ b/src/components/user/order/OrderTableHistoryCotent.tsx
@@ -59,7 +59,7 @@ function OrderTableHistoryContent(props: OrderTableHistoryProps) {
   return (
     <Container useFlex={colFlex({ justify: 'center', align: 'start' })}>
       <TableOrderLabel onClick={onClickTableOrderLabel} className={'table-order-label'}>
-        {`주문번호 ${props.id}번`}
+        {`주문번호 ${props.orderNumber}번`}
       </TableOrderLabel>
       <SubLabelContainer className={'sub-label-container'}>{createdDateAndOwnerText}</SubLabelContainer>
       {props.isShowDetail && <TableOrderCard {...props} />}

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -138,7 +138,7 @@ function OrderComplete() {
           </ContentTitleContainer>
           <ContentBox>
             <ContentText>주문일시 | {dateConverter(new Date(order.createdAt))}</ContentText>
-            <ContentText>주문번호 | {order.id}</ContentText>
+            <ContentText>주문번호 | {order.orderNumber}</ContentText>
             <ContentText>입금자명 | {order.customerName}</ContentText>
           </ContentBox>
 

--- a/src/types/defaultValues.ts
+++ b/src/types/defaultValues.ts
@@ -55,6 +55,7 @@ export const defaultUserOrderValue: Order = {
   totalPrice: 0,
   status: OrderStatus.NOT_PAID,
   cancelReason: '',
+  orderNumber: 0,
   id: 0,
   createdAt: '',
   updatedAt: '',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface Order {
   totalPrice: number;
   status: OrderStatus;
   cancelReason: string;
+  orderNumber: number;
   id: number;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 📚 개요

- order number 필드를 추가하고 적용했습니다. 이제 workspace 별로 주문 번호를 부여합니다.
- 라이브에서는 order number가 id 값을 가지도록 sql을 돌려줬는데 로컬에서는 해당 조치를 취하지 않아서 모두 0으로 보일 겁니다.

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/8fd53c3b-53ac-4de5-8f39-e53ea2052b4b" />

위에 2개가 redis 적용하고 난 모습입니다.

## 🕐 리뷰 예상 시간

> 5m