### PR TITLE
ADD - 다시 주문하기 버튼 추가

### DIFF
--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -183,7 +183,7 @@ function OrderComplete() {
         </ContentContainer>
         <OrderButton
           showButton={true}
-          buttonLabel={`다시 주문하기`}
+          buttonLabel={`더 주문하기`}
           onClick={() =>
             navigate({
               pathname: '/order',

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import useOrder from '@hooks/user/useOrder';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 import { orderBasketAtom, userOrderAtom, userWorkspaceAtom } from '@recoils/atoms';
-import { useSearchParams } from 'react-router-dom';
+import { createSearchParams, useNavigate, useSearchParams } from 'react-router-dom';
 import styled from '@emotion/styled';
 import useWorkspace from '@hooks/user/useWorkspace';
 import { colFlex, rowFlex } from '@styles/flexStyles';
@@ -11,6 +11,7 @@ import OrderStickyNavBar from '@components/admin/order/OrderStickyNavBar';
 import OrderStatusBar from '@components/user/order/OrderStatusBar';
 import useRefresh from '@hooks/useRefresh';
 import OrderAccountInfo from '@components/user/order/OrderAccountInfo';
+import OrderButton from '@components/user/order/OrderButton';
 
 const Container = styled.div`
   width: 100%;
@@ -99,9 +100,12 @@ const Description = styled.div`
 `;
 
 function OrderComplete() {
+  const navigate = useNavigate();
+
   const [searchParams] = useSearchParams();
   const orderId = searchParams.get('orderId');
   const workspaceId = searchParams.get('workspaceId');
+  const tableNo = searchParams.get('tableNo');
 
   const { fetchWorkspace } = useWorkspace();
   const { fetchOrder } = useOrder();
@@ -177,6 +181,19 @@ function OrderComplete() {
             <Description>{'결제가 원활하게 진행되지 않았을 경우,\n상단의 계좌 정보를 통해 직접 계좌이체를 부탁드립니다.'}</Description>
           </DescriptionContainer>
         </ContentContainer>
+        <OrderButton
+          showButton={true}
+          buttonLabel={`다시 주문하기`}
+          onClick={() =>
+            navigate({
+              pathname: '/order',
+              search: createSearchParams({
+                workspaceId: workspaceId || '',
+                tableNo: tableNo || '',
+              }).toString(),
+            })
+          }
+        />
       </SubContainer>
     </Container>
   );

--- a/src/pages/user/order/OrderPay.tsx
+++ b/src/pages/user/order/OrderPay.tsx
@@ -78,6 +78,7 @@ function OrderPay() {
         search: createSearchParams({
           orderId: res.data.id.toString(),
           workspaceId: workspaceId || '',
+          tableNo: tableNo || '',
         }).toString(),
       });
 
@@ -94,6 +95,7 @@ function OrderPay() {
         search: createSearchParams({
           orderId: res.data.id.toString(),
           workspaceId: workspaceId || '',
+          tableNo: tableNo || '',
         }).toString(),
       });
     });


### PR DESCRIPTION
## 📚 개요

<img width="369" alt="스크린샷 2025-03-24 오전 11 23 21" src="https://github.com/user-attachments/assets/8906860f-dc96-4406-ab8b-f5618fbd87f6" />

- 고객이 주문을 완료한 다음에 다시 주문할 수 있는 버튼을 추가했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- 주문 창을 닫거나, 새로운 주문을 했을 때, 이전 주문에 대한 상태를 확인 하고 싶을 때, 상단 바의 '공유' 아이콘을 통해서 클립보드에 링크를 복사했다면 해당 링크를 통해 확인할 수 있습니다.
- 해당 부분에 대해서 좀 더 정보를 명확히 제공해줘야할 것 같습니다.