### PR TITLE
ADD - 회원가입 페이지에 회원가입 가능한 이메일 도메인 링크 추가하기

### DIFF
--- a/src/components/common/input/AppInputWithLabel.tsx
+++ b/src/components/common/input/AppInputWithLabel.tsx
@@ -2,10 +2,12 @@ import React, { ForwardedRef, forwardRef } from 'react';
 import AppInput, { AppInputProps } from '@components/common/input/AppInput';
 import styled from '@emotion/styled';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { Color } from '@resources/colors';
 
 interface AppInputWithLabelProps extends AppInputProps {
   titleLabel: string;
   messageLabel?: string;
+  onMessageLabelClick?: () => void;
 }
 
 const Container = styled.div`
@@ -23,11 +25,16 @@ const TitleLabel = styled.label`
   font-weight: 500;
 `;
 
-const MessageLabel = styled.label`
+const MessageLabel = styled.label<{ clickable?: boolean }>`
   display: inline-block;
   padding: 0 10px 0;
   font-size: 12px;
   font-weight: 500;
+  text-decoration: ${(props) => (props.clickable ? 'underline' : 'none')};
+  cursor: ${(props) => (props.clickable ? 'pointer' : 'default')};
+  &:hover {
+    color: ${(props) => (props.clickable ? Color.KIO_ORANGE : Color.BLACK)};
+  }
 `;
 
 const AppInputWithLabel = forwardRef<HTMLInputElement, AppInputWithLabelProps>((props: AppInputWithLabelProps, ref: ForwardedRef<HTMLInputElement>) => {
@@ -37,7 +44,7 @@ const AppInputWithLabel = forwardRef<HTMLInputElement, AppInputWithLabelProps>((
         <TitleLabel htmlFor={props.id} className={'title-label'}>
           {props.titleLabel}
         </TitleLabel>
-        <MessageLabel htmlFor={props.id} className={'message-label'}>
+        <MessageLabel htmlFor={props.id} className={'message-label'} onClick={props.onMessageLabelClick} clickable={!!props.onMessageLabelClick}>
           {props.messageLabel}
         </MessageLabel>
       </LabelContainer>

--- a/src/pages/user/Register.tsx
+++ b/src/pages/user/Register.tsx
@@ -163,6 +163,10 @@ function Register() {
     setIsCodeSent(true);
   };
 
+  const navigateToEmailDomain = () => {
+    navigate('/email-domains');
+  };
+
   const checkCode = async () => {
     const userEmail = userEmailInputRef.current?.value;
     const inputCode = userCodeInputRef.current?.value;
@@ -235,6 +239,8 @@ function Register() {
             <AppInputWithLabel
               style={{ width: '330px' }}
               titleLabel={'이메일'}
+              messageLabel={'회원가입 가능한 이메일 확인하기'}
+              onMessageLabelClick={navigateToEmailDomain}
               type={'email'}
               id={'userEmail'}
               ref={userEmailInputRef}


### PR DESCRIPTION
## 📚 개요

- 회원가입 페이지에 회원가입 가능한 이메일 도메인 링크 추가했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

<img width="1730" alt="image" src="https://github.com/user-attachments/assets/0dfe2372-434b-4b5a-aaec-12cbfe83c24f" />
