### PR TITLE
ADD - 주문 모달창에서 esc 버튼으로 끌 수 있게 이벤트리스너 추가

### DIFF
--- a/src/components/admin/order/modal/OrderDetailModalButton.tsx
+++ b/src/components/admin/order/modal/OrderDetailModalButton.tsx
@@ -9,6 +9,7 @@ import useModal from '@hooks/useModal';
 import { RiArrowRightSLine } from '@remixicon/react';
 import { expandButtonStyle } from '@styles/buttonStyles';
 import { createPortal } from 'react-dom';
+import { useEffect } from 'react';
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -46,6 +47,14 @@ interface Props {
 
 function OrderDetailModalButton({ order }: Props) {
   const { isModalOpen, openModal, closeModal, modalKey } = useModal();
+
+  useEffect(() => {
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        closeModal();
+      }
+    });
+  }, []);
 
   if (!isModalOpen) {
     return <RightIcon onClick={openModal} />;


### PR DESCRIPTION
## 📚 개요

- 주문 모달창에서 esc 버튼으로 끌 수 있게 이벤트리스너 추가했습니다.

## 🕐 리뷰 예상 시간

> 2m