### PR TITLE
FIX - 주문 상세 모달을 열고 상태 변화 시, 스크롤이 안되는 버그 수정

### DIFF
--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -3,15 +3,16 @@ import { Order } from '@@types/index';
 import AppLabel from '@components/common/label/AppLabel';
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
-import { RiCloseLargeLine, RiCheckLine } from '@remixicon/react';
+import { RiCloseLargeLine, RiCheckLine, RiArrowRightSLine } from '@remixicon/react';
 import { expandButtonStyle } from '@styles/buttonStyles';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import OrderSummaryContents from './OrderSummaryContents';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import { useParams } from 'react-router-dom';
-import OrderDetailModalButton from '@components/admin/order/modal/OrderDetailModalButton';
+import OrderDetailModal from '@components/admin/order/modal/OrderDetailModal';
 import { areOrdersEquivalent } from '@utils/MemoCompareFunction';
 import useDelayTime from '@hooks/useDelayTime';
+import useModal from '@hooks/useModal';
 
 const CardContainer = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })}
@@ -36,6 +37,11 @@ const CardContents = styled.div`
   height: 85%;
 `;
 
+const OrderInfoContainer = styled.div`
+  width: 100%;
+  cursor: pointer;
+`;
+
 const HeaderContainer = styled.div`
   ${rowFlex({ justify: 'space-between', align: 'start' })}
   width: 100%;
@@ -50,6 +56,12 @@ const CheckButtonContainer = styled.div`
   ${rowFlex({ justify: 'center', align: 'center' })}
   gap: 35px;
   width: 55%;
+`;
+
+const RightIcon = styled(RiArrowRightSLine)`
+  width: 25px;
+  height: 25px;
+  ${expandButtonStyle}
 `;
 
 const CheckIcon = styled(RiCheckLine)`
@@ -76,6 +88,7 @@ function NotPaidOrderCard({ order }: OrderCardProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const { payOrder, cancelOrder } = useAdminOrder(workspaceId);
   const { delayMinutes } = useDelayTime({ date: order.createdAt });
+  const { isModalOpen, openModal, closeModal } = useModal();
 
   const checkClickHandler = () => {
     payOrder(order.id);
@@ -85,20 +98,27 @@ function NotPaidOrderCard({ order }: OrderCardProps) {
     cancelOrder(order.id);
   };
 
+  const orderInfoClickHandler = () => {
+    if (!isModalOpen) openModal();
+  };
+
   return (
     <>
       <CardContainer>
         <CardContents>
-          <HeaderContainer>
-            <TitleContainer>
-              <AppLabel color={Color.BLACK} size={17} style={{ fontWeight: 800 }}>
-                {order.customerName}
-              </AppLabel>
-              <AppLabel color={Color.BLACK} size={13}>{`${delayMinutes}분 전 주문`}</AppLabel>
-            </TitleContainer>
-            <OrderDetailModalButton order={order} />
-          </HeaderContainer>
-          <OrderSummaryContents contents={order} />
+          <OrderInfoContainer onClick={orderInfoClickHandler}>
+            <HeaderContainer>
+              <TitleContainer>
+                <AppLabel color={Color.BLACK} size={17} style={{ fontWeight: 800 }}>
+                  {order.customerName}
+                </AppLabel>
+                <AppLabel color={Color.BLACK} size={13}>{`${delayMinutes}분 전 주문`}</AppLabel>
+              </TitleContainer>
+              <RightIcon onClick={openModal} />
+              <OrderDetailModal order={order} isModalOpen={isModalOpen} closeModal={closeModal} />
+            </HeaderContainer>
+            <OrderSummaryContents contents={order} />
+          </OrderInfoContainer>
           <CheckButtonContainer>
             <CheckIcon onClick={checkClickHandler} />
             <CloseIcon onClick={closeClickHandler} />

--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -16,7 +16,7 @@ import useModal from '@hooks/useModal';
 
 const CardContainer = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })}
-  background-color: ${Color.LIGHT_GREY};
+  background-color: #f4f4f4;
   width: 200px;
   height: 170px;
   border-radius: 10px;
@@ -33,11 +33,14 @@ const CardContainer = styled.div`
 
 const CardContents = styled.div`
   ${colFlex({ justify: 'space-between', align: 'center' })}
-  width: 80%;
+  width: 100%;
   height: 85%;
 `;
 
 const OrderInfoContainer = styled.div`
+  background-color: ${Color.LIGHT_GREY};
+  box-sizing: border-box;
+  padding: 15px;
   width: 100%;
   cursor: pointer;
 `;

--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -25,6 +25,7 @@ const CardContainer = styled.div`
     background-color: ${Color.KIO_ORANGE};
 
     & * {
+      background-color: ${Color.KIO_ORANGE};
       color: ${Color.WHITE};
       stroke: ${Color.WHITE};
     }

--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -35,7 +35,7 @@ const CardContainer = styled.div`
 const CardContents = styled.div`
   ${colFlex({ justify: 'space-between', align: 'center' })}
   width: 100%;
-  height: 85%;
+  height: 90%;
 `;
 
 const OrderInfoContainer = styled.div`

--- a/src/components/admin/order/NotPaidOrderCard.tsx
+++ b/src/components/admin/order/NotPaidOrderCard.tsx
@@ -39,9 +39,11 @@ const CardContents = styled.div`
 `;
 
 const OrderInfoContainer = styled.div`
+  ${colFlex()}
+  gap: 15px;
   background-color: ${Color.LIGHT_GREY};
   box-sizing: border-box;
-  padding: 15px;
+  padding: 5px 15px;
   width: 100%;
   cursor: pointer;
 `;

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -17,7 +17,7 @@ import useModal from '@hooks/useModal';
 
 const CardContainer = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })}
-  background-color: ${Color.LIGHT_GREY};
+  background-color: #f4f4f4;
   width: 200px;
   height: 170px;
   border-radius: 10px;
@@ -34,11 +34,14 @@ const CardContainer = styled.div`
 
 const CardContents = styled.div`
   ${colFlex({ justify: 'space-between', align: 'center' })}
-  width: 80%;
+  width: 100%;
   height: 85%;
 `;
 
 const OrderInfoContainer = styled.div`
+  background-color: ${Color.LIGHT_GREY};
+  box-sizing: border-box;
+  padding: 15px;
   width: 100%;
   cursor: pointer;
 `;

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -3,16 +3,17 @@ import { Order } from '@@types/index';
 import AppLabel from '@components/common/label/AppLabel';
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
-import { RiCheckLine } from '@remixicon/react';
+import { RiArrowRightSLine, RiCheckLine } from '@remixicon/react';
 import { expandButtonStyle } from '@styles/buttonStyles';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import { useParams } from 'react-router-dom';
 import RollBackSvg from '@resources/svg/RollBackSvg';
-import OrderDetailModalButton from '@components/admin/order/modal/OrderDetailModalButton';
+import OrderDetailModal from '@components/admin/order/modal/OrderDetailModal';
 import OrderItemList from '@components/admin/order/OrderItemList';
 import { areOrdersEquivalent } from '@utils/MemoCompareFunction';
 import useDelayTime from '@hooks/useDelayTime';
+import useModal from '@hooks/useModal';
 
 const CardContainer = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })}
@@ -35,6 +36,11 @@ const CardContents = styled.div`
   ${colFlex({ justify: 'space-between', align: 'center' })}
   width: 80%;
   height: 85%;
+`;
+
+const OrderInfoContainer = styled.div`
+  width: 100%;
+  cursor: pointer;
 `;
 
 const HeaderContainer = styled.div`
@@ -65,6 +71,12 @@ const RollBackIcon = styled(RollBackSvg)`
   ${expandButtonStyle}
 `;
 
+const RightIcon = styled(RiArrowRightSLine)`
+  width: 25px;
+  height: 25px;
+  ${expandButtonStyle}
+`;
+
 interface OrderCardProps {
   order: Order;
 }
@@ -77,6 +89,7 @@ function PaidOrderCard({ order }: OrderCardProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const { serveOrder, refundOrder } = useAdminOrder(workspaceId);
   const { delayMinutes } = useDelayTime({ date: order.createdAt });
+  const { isModalOpen, openModal, closeModal } = useModal();
 
   const checkClickHandler = () => {
     serveOrder(order.id);
@@ -86,20 +99,27 @@ function PaidOrderCard({ order }: OrderCardProps) {
     refundOrder(order.id);
   };
 
+  const orderInfoClickHandler = () => {
+    if (!isModalOpen) openModal();
+  };
+
   return (
     <>
       <CardContainer>
         <CardContents>
-          <HeaderContainer>
-            <TitleContainer>
-              <AppLabel color={Color.BLACK} size={17} style={{ fontWeight: 800 }}>
-                {`테이블 ${order.tableNumber}`}
-              </AppLabel>
-              <AppLabel color={Color.BLACK} size={13}>{`${delayMinutes}분 전 주문`}</AppLabel>
-            </TitleContainer>
-            <OrderDetailModalButton order={order} />
-          </HeaderContainer>
-          <OrderItemList order={order} />
+          <OrderInfoContainer onClick={orderInfoClickHandler}>
+            <HeaderContainer>
+              <TitleContainer>
+                <AppLabel color={Color.BLACK} size={17} style={{ fontWeight: 800 }}>
+                  {`테이블 ${order.tableNumber}`}
+                </AppLabel>
+                <AppLabel color={Color.BLACK} size={13}>{`${delayMinutes}분 전 주문`}</AppLabel>
+              </TitleContainer>
+              <RightIcon onClick={openModal} />
+              <OrderDetailModal order={order} isModalOpen={isModalOpen} closeModal={closeModal} />
+            </HeaderContainer>
+            <OrderItemList order={order} />
+          </OrderInfoContainer>
           <CheckButtonContainer>
             <CheckIcon onClick={checkClickHandler} />
             <RollBackIcon onClick={rollBackClickHandler} />

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -36,7 +36,7 @@ const CardContainer = styled.div`
 const CardContents = styled.div`
   ${colFlex({ justify: 'space-between', align: 'center' })}
   width: 100%;
-  height: 85%;
+  height: 90%;
 `;
 
 const OrderInfoContainer = styled.div`

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -40,9 +40,11 @@ const CardContents = styled.div`
 `;
 
 const OrderInfoContainer = styled.div`
+  ${colFlex()}
+  gap: 15px;
   background-color: ${Color.LIGHT_GREY};
   box-sizing: border-box;
-  padding: 15px;
+  padding: 5px 15px;
   width: 100%;
   cursor: pointer;
 `;

--- a/src/components/admin/order/PaidOrderCard.tsx
+++ b/src/components/admin/order/PaidOrderCard.tsx
@@ -26,6 +26,7 @@ const CardContainer = styled.div`
     background-color: ${Color.KIO_ORANGE};
 
     & * {
+      background-color: ${Color.KIO_ORANGE};
       color: ${Color.WHITE};
       stroke: ${Color.WHITE};
     }

--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -39,13 +39,14 @@ const CardContents = styled.div`
 `;
 
 const OrderInfoContainer = styled.div`
+  ${colFlex()}
+  gap: 15px;
   background-color: ${Color.LIGHT_GREY};
   box-sizing: border-box;
-  padding: 15px;
+  padding: 5px 15px;
   width: 100%;
   cursor: pointer;
 `;
-
 const HeaderContainer = styled.div`
   ${rowFlex({ justify: 'space-between', align: 'start' })}
   width: 100%;

--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -9,8 +9,10 @@ import OrderSummaryContents from './OrderSummaryContents';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import { useParams } from 'react-router-dom';
 import RollBackSvg from '@resources/svg/RollBackSvg';
-import OrderDetailModalButton from '@components/admin/order/modal/OrderDetailModalButton';
+import OrderDetailModal from '@components/admin/order/modal/OrderDetailModal';
 import { areOrdersEquivalent } from '@utils/MemoCompareFunction';
+import useModal from '@hooks/useModal';
+import { RiArrowRightSLine } from '@remixicon/react';
 
 const CardContainer = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })}
@@ -35,6 +37,11 @@ const CardContents = styled.div`
   height: 85%;
 `;
 
+const OrderInfoContainer = styled.div`
+  width: 100%;
+  cursor: pointer;
+`;
+
 const HeaderContainer = styled.div`
   ${rowFlex({ justify: 'space-between', align: 'start' })}
   width: 100%;
@@ -49,6 +56,12 @@ const CheckButtonContainer = styled.div`
   ${rowFlex({ justify: 'center', align: 'center' })}
   gap: 35px;
   width: 55%;
+`;
+
+const RightIcon = styled(RiArrowRightSLine)`
+  width: 25px;
+  height: 25px;
+  ${expandButtonStyle}
 `;
 
 const RollBackIcon = styled(RollBackSvg)`
@@ -68,27 +81,35 @@ const arePropsEqual = (prevProps: OrderCardProps, nextProps: OrderCardProps) => 
 function ServedOrderCard({ order }: OrderCardProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const { payOrder } = useAdminOrder(workspaceId);
+  const { isModalOpen, openModal, closeModal } = useModal();
 
   const rollBackClickHandler = () => {
     payOrder(order.id);
+  };
+
+  const orderInfoClickHandler = () => {
+    if (!isModalOpen) openModal();
   };
 
   return (
     <>
       <CardContainer>
         <CardContents>
-          <HeaderContainer>
-            <TitleContainer>
-              <AppLabel color={Color.BLACK} size={17} style={{ fontWeight: 800 }}>
-                {`테이블 ${order.tableNumber}`}
-              </AppLabel>
-              <AppLabel color={Color.BLACK} size={13}>
-                {`주문 번호 ${order.orderNumber}`}
-              </AppLabel>
-            </TitleContainer>
-            <OrderDetailModalButton order={order} />
-          </HeaderContainer>
-          <OrderSummaryContents contents={order} />
+          <OrderInfoContainer onClick={orderInfoClickHandler}>
+            <HeaderContainer>
+              <TitleContainer>
+                <AppLabel color={Color.BLACK} size={17} style={{ fontWeight: 800 }}>
+                  {`테이블 ${order.tableNumber}`}
+                </AppLabel>
+                <AppLabel color={Color.BLACK} size={13}>
+                  {`주문 번호 ${order.orderNumber}`}
+                </AppLabel>
+              </TitleContainer>
+              <RightIcon onClick={openModal} />
+              <OrderDetailModal order={order} isModalOpen={isModalOpen} closeModal={closeModal} />
+            </HeaderContainer>
+            <OrderSummaryContents contents={order} />
+          </OrderInfoContainer>
           <CheckButtonContainer>
             <RollBackIcon onClick={rollBackClickHandler} />
           </CheckButtonContainer>

--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -16,7 +16,7 @@ import { RiArrowRightSLine } from '@remixicon/react';
 
 const CardContainer = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })}
-  background-color: ${Color.LIGHT_GREY};
+  background-color: #f4f4f4;
   width: 200px;
   height: 170px;
   border-radius: 10px;
@@ -33,11 +33,14 @@ const CardContainer = styled.div`
 
 const CardContents = styled.div`
   ${colFlex({ justify: 'space-between', align: 'center' })}
-  width: 80%;
+  width: 100%;
   height: 85%;
 `;
 
 const OrderInfoContainer = styled.div`
+  background-color: ${Color.LIGHT_GREY};
+  box-sizing: border-box;
+  padding: 15px;
   width: 100%;
   cursor: pointer;
 `;

--- a/src/components/admin/order/ServedOrderCard.tsx
+++ b/src/components/admin/order/ServedOrderCard.tsx
@@ -25,6 +25,7 @@ const CardContainer = styled.div`
     background-color: ${Color.KIO_ORANGE};
 
     & * {
+      background-color: ${Color.KIO_ORANGE};
       color: ${Color.WHITE};
       stroke: ${Color.WHITE};
     }

--- a/src/components/admin/order/modal/OrderDetailModal.tsx
+++ b/src/components/admin/order/modal/OrderDetailModal.tsx
@@ -40,6 +40,7 @@ interface Props {
 }
 function OrderDetailModal({ order, isModalOpen, closeModal }: Props) {
   const { modalKey } = useModal();
+
   useEffect(() => {
     window.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') {

--- a/src/components/admin/order/modal/OrderDetailModal.tsx
+++ b/src/components/admin/order/modal/OrderDetailModal.tsx
@@ -5,11 +5,9 @@ import { colFlex } from '@styles/flexStyles';
 import OrderModalFooterContents from '@components/admin/order/modal/OrderModalFooterContents';
 import OrderModalMainContents from '@components/admin/order/modal/OrderModalMainContents';
 import OrderModalHeaderContents from '@components/admin/order/modal/OrderModalHeaderContents';
-import useModal from '@hooks/useModal';
-import { RiArrowRightSLine } from '@remixicon/react';
-import { expandButtonStyle } from '@styles/buttonStyles';
 import { createPortal } from 'react-dom';
 import { useEffect } from 'react';
+import useModal from '@hooks/useModal';
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -35,19 +33,13 @@ const ModalContainer = styled.div`
   gap: 15px;
 `;
 
-const RightIcon = styled(RiArrowRightSLine)`
-  width: 25px;
-  height: 25px;
-  ${expandButtonStyle}
-`;
-
 interface Props {
   order: Order;
+  isModalOpen: boolean;
+  closeModal: () => void;
 }
-
-function OrderDetailModalButton({ order }: Props) {
-  const { isModalOpen, openModal, closeModal, modalKey } = useModal();
-
+function OrderDetailModal({ order, isModalOpen, closeModal }: Props) {
+  const { modalKey } = useModal();
   useEffect(() => {
     window.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') {
@@ -57,7 +49,7 @@ function OrderDetailModalButton({ order }: Props) {
   }, []);
 
   if (!isModalOpen) {
-    return <RightIcon onClick={openModal} />;
+    return null;
   }
 
   return createPortal(
@@ -73,4 +65,4 @@ function OrderDetailModalButton({ order }: Props) {
   );
 }
 
-export default OrderDetailModalButton;
+export default OrderDetailModal;

--- a/src/components/admin/order/modal/OrderDetailModalButton.tsx
+++ b/src/components/admin/order/modal/OrderDetailModalButton.tsx
@@ -66,7 +66,7 @@ function OrderDetailModalButton({ order }: Props) {
       <ModalContainer>
         <OrderModalHeaderContents onClose={closeModal} order={order} />
         <OrderModalMainContents order={order} />
-        <OrderModalFooterContents orderStatus={order.status} id={order.id} />
+        <OrderModalFooterContents orderStatus={order.status} id={order.id} closeModal={closeModal} />
       </ModalContainer>
     </>,
     document.getElementById(modalKey) as HTMLElement,

--- a/src/components/admin/order/modal/OrderModalFooterContents.tsx
+++ b/src/components/admin/order/modal/OrderModalFooterContents.tsx
@@ -13,6 +13,7 @@ const ModalFooter = styled.div`
 interface OrderModalFooterContentsProps {
   orderStatus: OrderStatus;
   id: number;
+  closeModal: () => void;
 }
 
 const getActions = (orderStatus: OrderStatus, actionHandlers: Record<string, () => void>) => {
@@ -34,15 +35,27 @@ const getActions = (orderStatus: OrderStatus, actionHandlers: Record<string, () 
   }
 };
 
-function OrderModalFooterContents({ orderStatus, id }: OrderModalFooterContentsProps) {
+function OrderModalFooterContents({ orderStatus, id, closeModal }: OrderModalFooterContentsProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const { payOrder, cancelOrder, serveOrder, refundOrder } = useAdminOrder(workspaceId);
 
   const actionHandlers = {
-    payOrder: () => payOrder(id),
-    cancelOrder: () => cancelOrder(id),
-    serveOrder: () => serveOrder(id),
-    refundOrder: () => refundOrder(id),
+    payOrder: () => {
+      closeModal();
+      payOrder(id);
+    },
+    cancelOrder: () => {
+      closeModal();
+      cancelOrder(id);
+    },
+    serveOrder: () => {
+      closeModal();
+      serveOrder(id);
+    },
+    refundOrder: () => {
+      closeModal();
+      refundOrder(id);
+    },
   };
 
   const actions = getActions(orderStatus, actionHandlers);

--- a/src/pages/admin/order/AdminOrderRealtime.tsx
+++ b/src/pages/admin/order/AdminOrderRealtime.tsx
@@ -34,7 +34,13 @@ function AdminOrderRealtime() {
   }, []);
 
   return (
-    <AppContainer useFlex={colFlex({ justify: 'center' })} customGap={'15px'} useScroll={true} titleNavBarProps={{ title: '실시간 주문 조회' }}>
+    <AppContainer
+      useFlex={colFlex({ justify: 'center' })}
+      customGap={'15px'}
+      useScroll={true}
+      titleNavBarProps={{ title: '실시간 주문 조회' }}
+      useNavBackground={true}
+    >
       <>
         <TitledOrderStatusList orders={notPaidOrders} title={'주문 완료'} />
         <HorizontalLine />


### PR DESCRIPTION
## 📚 개요

## BEFORE

https://github.com/user-attachments/assets/c52667a8-9684-4c4c-acdc-df0111695faa



## AFTER

https://github.com/user-attachments/assets/4f75e29f-dd47-4a69-945c-fc071e8a9f19


- 주문 상세 모달을 열고난 후, 주문 상태를 변화시키면 스크롤이 안되는 버그를 수정했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

```js
function useModal() {
  const modalKey = 'modal-root';
  const [isModalOpen, setModalOpen] = useState(false);

  const openModal = () => {
    setModalOpen(true);
    // 모달창 open 시 배경 스크롤 금지 코드
    document.body.style.overflow = 'hidden';
  };

  const closeModal = () => {
    setModalOpen(false);
    // 모달창 open 시 배경 스크롤 금지 해제 코드
    document.body.style.overflow = 'auto';
  };

  return { isModalOpen, openModal, closeModal, modalKey };
}
```
- 위와 같이 모달이 열렸을 때, 배경 화면이 스크롤이 안되도록 하는 코드가 있습니다.
- `closeModal`을 호출해야지 배경 스크롤 금지가 해제됩니다.
- 주문 상태를 변화시키는 로직에서 `closeModal`을 호출하지 않았기에 스크롤이 계속 금지되어 발생한 문제였습니다.

```js
    refundOrder: () => {
      closeModal();
      refundOrder(id);
    },
```
- 위와 같이 주문 상태를 변화시키기 전에 `closeModal`을 호출하도록 했습니다.