### PR TITLE
FIX - 홈 화면 모바일 뷰 깨지는 현상 해결

### DIFF
--- a/src/pages/user/home/HomeMobile.tsx
+++ b/src/pages/user/home/HomeMobile.tsx
@@ -37,7 +37,7 @@ const Grass = styled.div<{
   zIndex: number;
 }>`
   position: absolute;
-  bottom: 35%;
+  bottom: 30%;
   left: ${({ left }) => left};
   transform: translateX(-50%);
   width: ${({ size = '60px' }) => size};
@@ -51,13 +51,13 @@ const Ground = styled.div`
   position: absolute;
   bottom: 0;
   width: 100%;
-  height: 35%;
+  height: 30%;
   background-color: #7fc47f;
 `;
 
 const SignBoard = styled.div`
   position: absolute;
-  bottom: 300px;
+  bottom: 30%;
   left: 50%;
   transform: translateX(-50%);
   width: 85%;


### PR DESCRIPTION
## 📚 개요

### BEFORE
<img width="422" alt="스크린샷 2025-04-21 오후 2 40 10" src="https://github.com/user-attachments/assets/57f19031-4a99-447f-894f-8c85981b07d1" />

### AFTER
<img width="434" alt="스크린샷 2025-04-21 오후 2 40 33" src="https://github.com/user-attachments/assets/424d2317-47da-441d-909b-6bbe148db14e" />

- 홈 화면이 모바일 뷰에서 깨지는 현상을 해결했습니다.


## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)
- Graas, SignBoard, Ground 3개의 컴포넌트에 대해 bottom css 값의 단위를 %로 통일했습니다.