### PR TITLE
ADD - useNetwork 훅과 react-toastify 라이브러리를 통한 네트워크 연결 상태 알림 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-router-dom": "^6.20.1",
     "react-scripts": "5.0.1",
     "react-scroll": "npm:@kioschool/react-scroll",
+    "react-toastify": "^11.0.5",
     "recoil": "^0.7.5",
     "recoil-persist": "^5.1.0",
     "web-vitals": "^2.1.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import Register from '@pages/user/Register';
 import AdminProduct from '@pages/admin/AdminProduct';
 import Order from '@pages/user/order/Order';
 import AdminAccount from '@pages/admin/AdminAccount';
-import { RecoilRoot } from 'recoil';
 import LoadingModal from '@components/common/modal/LoadingModal';
 import { Global } from '@emotion/react';
 import { globalStyles } from '@styles/globalStyles';
@@ -36,14 +35,30 @@ import SuperAdminEmailDomainList from '@pages/super-admin/SuperAdminEmailDomainL
 import UserEmailDomain from '@pages/user/UserEmailDomain';
 import AdminWorkspaceEdit from '@pages/admin/AdminWorkspaceEdit';
 import SuperAdminBank from '@pages/super-admin/SuperAdminBank';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import { RecoilRoot } from 'recoil';
+import useNetworkStatusNotifier from '@hooks/useNetworkStatusNotifier';
 
 ReactGA.initialize('G-XGYLSPGK2G');
 
 function App() {
   RouterChangeTracker();
+  useNetworkStatusNotifier();
 
   return (
     <RecoilRoot>
+      <ToastContainer
+        position="top-right"
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+      />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />

--- a/src/hooks/useNetwork.tsx
+++ b/src/hooks/useNetwork.tsx
@@ -1,0 +1,88 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+const verifyConnectivity = async (timeout = 5000): Promise<boolean> => {
+  const testUrl = `https://www.google.com/favicon.ico?t=${Date.now()}`;
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    await fetch(testUrl, {
+      method: 'HEAD',
+      mode: 'no-cors',
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+    return true;
+  } catch (error) {
+    console.warn(`Network connectivity check to ${testUrl} failed:`, error);
+    return false;
+  }
+};
+
+function useNetwork(checkInterval = 5000): boolean {
+  const [isOnline, setIsOnline] = useState<boolean>(navigator.onLine);
+  const isChecking = useRef(false);
+  const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
+
+  const performCheck = useCallback(async (triggeredByEvent = false) => {
+    if (isChecking.current) return;
+    isChecking.current = true;
+
+    let currentStatus: boolean;
+    if (!navigator.onLine) {
+      currentStatus = false;
+    } else {
+      if (triggeredByEvent) {
+        console.log('브라우저가 온라인 상태로 변경되었습니다.');
+      }
+      currentStatus = await verifyConnectivity();
+    }
+
+    setIsOnline((prevIsOnline) => {
+      if (prevIsOnline !== currentStatus) {
+        console.log(`Verified connection status: ${currentStatus}`);
+        return currentStatus;
+      }
+      return prevIsOnline;
+    });
+
+    isChecking.current = false;
+  }, []);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      performCheck(true);
+    };
+
+    const handleOffline = () => {
+      console.log('Browser reported offline.');
+      setIsOnline((prevIsOnline) => (prevIsOnline ? false : prevIsOnline));
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    performCheck();
+
+    intervalIdRef.current = setInterval(() => {
+      if (navigator.onLine) {
+        performCheck();
+      }
+    }, checkInterval);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
+      }
+    };
+  }, [performCheck]);
+
+  return isOnline;
+}
+
+export default useNetwork;

--- a/src/hooks/useNetwork.tsx
+++ b/src/hooks/useNetwork.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 const verifyConnectivity = async (timeout = 5000): Promise<boolean> => {
   const fetchUrl = `https://www.google.com/favicon.ico?t=${Date.now()}`;
@@ -23,20 +23,12 @@ const verifyConnectivity = async (timeout = 5000): Promise<boolean> => {
   }
 };
 
-function useNetwork(checkInterval = 5000): boolean {
+function useNetwork(): boolean {
   const [isOnline, setIsOnline] = useState<boolean>(navigator.onLine);
-  const isChecking = useRef(false);
-  const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
 
   const performCheck = useCallback(async () => {
-    if (isChecking.current) return;
-    isChecking.current = true;
-
     const currentStatus = await verifyConnectivity();
-
     setIsOnline(currentStatus);
-
-    isChecking.current = false;
   }, []);
 
   useEffect(() => {
@@ -51,18 +43,9 @@ function useNetwork(checkInterval = 5000): boolean {
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
 
-    intervalIdRef.current = setInterval(() => {
-      if (navigator.onLine) {
-        performCheck();
-      }
-    }, checkInterval);
-
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
-      if (intervalIdRef.current) {
-        clearInterval(intervalIdRef.current);
-      }
     };
   }, []);
 

--- a/src/hooks/useNetworkStatusNotifier.tsx
+++ b/src/hooks/useNetworkStatusNotifier.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { toast } from 'react-toastify';
+import useNetwork from '@hooks/useNetwork';
+
+function useNetworkStatusNotifier() {
+  const isOnline = useNetwork();
+  const previousOnlineStatusRef = useRef<boolean>(isOnline);
+
+  useEffect(() => {
+    const previousStatus = previousOnlineStatusRef.current;
+
+    if (previousStatus && !isOnline) {
+      toast.error('네트워크 연결이 끊어졌습니다.', {
+        toastId: 'network-offline',
+        autoClose: false,
+        closeOnClick: false,
+        draggable: false,
+        position: 'top-right',
+        theme: 'light',
+      });
+    } else if (!previousStatus && isOnline) {
+      toast.dismiss('network-offline');
+      toast.success('네트워크 연결이 복구되었습니다.', {
+        toastId: 'network-online',
+        autoClose: 5000,
+        position: 'top-right',
+        theme: 'light',
+      });
+    }
+
+    previousOnlineStatusRef.current = isOnline;
+  }, [isOnline]);
+}
+
+export default useNetworkStatusNotifier;

--- a/src/hooks/useNetworkStatusNotifier.tsx
+++ b/src/hooks/useNetworkStatusNotifier.tsx
@@ -10,6 +10,7 @@ function useNetworkStatusNotifier() {
     const previousStatus = previousOnlineStatusRef.current;
 
     if (previousStatus && !isOnline) {
+      toast.dismiss('network-online');
       toast.error('네트워크 연결이 끊어졌습니다.', {
         toastId: 'network-offline',
         autoClose: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4624,6 +4624,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -9847,6 +9852,13 @@ react-scripts@5.0.1:
   dependencies:
     lodash.throttle "^4.1.1"
     prop-types "^15.7.2"
+
+react-toastify@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-11.0.5.tgz#ce4c42d10eeb433988ab2264d3e445c4e9d13313"
+  integrity sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==
+  dependencies:
+    clsx "^2.1.1"
 
 "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
   version "19.1.0"


### PR DESCRIPTION
## 📚 개요

### PC
https://github.com/user-attachments/assets/829a7af1-d9ab-43a9-b3cc-301ea927599d

### Mobile
https://github.com/user-attachments/assets/5c0898a1-bc7f-4172-a61c-3deac3ce0535


- 사용자의 인터넷 연결 상태를 알아내고, 연결이 되어있지 않다면 '네트워크 연결이 끊어졌습니다.' 토스트 ui를 보여줍니다.
- 연결이 다시 된다면 '네트워크 연결이 복구되었습니다.' 토스트 ui를 보여줍니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

`navigator.onLine` 프로퍼티는 네트워크 인터페이스에 연결된 상태만 알려주며, 실제 인터넷 접근 가능 여부는 보장하지 않습니다. 따라서 다음과 같이 추가적인 검증 과정을 거칩니다.

1. **온라인 상태 확인**  
   - `navigator.onLine === true`일 때만 `performCheck()` 호출  
   
2. **진짜 연결 테스트 (`performCheck`)**  
   - Google의 작은 리소스(`google.com/favicon.ico`)에 `HEAD` 요청  
   - 응답 성공 → `setIsOnline(true)`  
   - 타임아웃/에러 → `setIsOnline(false)`  

> **참고**  
> - `window`의 [online](https://developer.mozilla.org/en-US/docs/Web/API/Window/online_event) 이벤트는 `navigator.onLine`이 `true`로 전환될 때 발생합니다.  
> - `offline` 이벤트는 `navigator.onLine`이 `false`로 전환될 때 발생합니다.


```ts
useEffect(() => {
  // 네트워크 인터페이스가 복구됐을 때, 실제 인터넷 연결 재검증
  const handleOnline = () => performCheck();

  // 네트워크 인터페이스가 끊겼을 때, 즉시 오프라인 처리
  const handleOffline = () => setIsOnline(false);

  window.addEventListener('online', handleOnline);
  window.addEventListener('offline', handleOffline);

  return () => {
    window.removeEventListener('online', handleOnline);
    window.removeEventListener('offline', handleOffline);
  };
}, []);
