### PR TITLE
FIX - 모달 스크롤 금지 버그 수정

### DIFF
--- a/src/components/admin/order/modal/OrderDetailModal.tsx
+++ b/src/components/admin/order/modal/OrderDetailModal.tsx
@@ -47,6 +47,10 @@ function OrderDetailModal({ order, isModalOpen, closeModal }: Props) {
         closeModal();
       }
     });
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
   }, []);
 
   if (!isModalOpen) {


### PR DESCRIPTION
## 📚 개요



### BEFORE

https://github.com/user-attachments/assets/8f0b19db-bf43-42f6-bf37-ea894256280e

### AFTER
https://github.com/user-attachments/assets/889a650b-c217-4650-84f8-6741355acfae

- 소켓 통신 상황에서 보고 있던 주문 모달 창이 예기치 않게 닫히는 경우, 모달을 열 때 설정한 `overflow: hidden` 속성이 그대로 남게 되어 스크롤이 막힙니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)
```ts
function OrderDetailModal({ order, isModalOpen, closeModal }: Props) {
  const { modalKey } = useModal();

  useEffect(() => {
   // logic. . .
    return () => {
      document.body.style.overflow = 'auto';
    };
  }, []);
```
- OrderDetailModal 이 언마운트 될 때, `overflow: auto`로 설정하여 스크롤이 이루어지도록 합니다.