### PR TITLE
EDIT - "누적 매출 증가 추이"를 "시간대별 매출"로 변경

### DIFF
--- a/src/components/admin/order/statistic/OrderPriceStatistics.tsx
+++ b/src/components/admin/order/statistic/OrderPriceStatistics.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import { useParams } from 'react-router-dom';
 import { format } from 'date-fns';
@@ -24,9 +24,9 @@ const FallbackContainer = styled.div`
   font-weight: 600;
 `;
 
-export interface ApiPoint {
+export interface OrderHourlyPrice {
   timeBucket: string;
-  OrderPrefixSumPrice: number;
+  price: number;
 }
 
 interface OrderPriceStatisticsProps {
@@ -37,8 +37,8 @@ interface OrderPriceStatisticsProps {
 
 function OrderPriceStatistics({ startDate, endDate, status }: OrderPriceStatisticsProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>();
-  const { fetchPrefixSumOrders } = useAdminOrder(workspaceId);
-  const [data, setData] = useState<ApiPoint[]>([]);
+  const { fetchOrderHourlyPrices } = useAdminOrder(workspaceId);
+  const [data, setData] = useState<OrderHourlyPrice[]>([]);
 
   const formatDateLabel = (iso: string, pattern: string) => {
     const date = toZonedTime(new Date(iso), 'Asia/Seoul');
@@ -47,7 +47,7 @@ function OrderPriceStatistics({ startDate, endDate, status }: OrderPriceStatisti
 
   const fetchOrderPriceStatistics = async () => {
     try {
-      const response = await fetchPrefixSumOrders({
+      const response = await fetchOrderHourlyPrices({
         startDate,
         endDate,
         status,
@@ -93,10 +93,10 @@ function OrderPriceStatistics({ startDate, endDate, status }: OrderPriceStatisti
           <YAxis tickFormatter={YAxisFormatter} />
           <Tooltip
             labelFormatter={(iso) => formatDateLabel(iso, 'yyyy-MM-dd HH:mm')}
-            formatter={(value: number) => [`${value.toLocaleString()}원`, '누적 매출']}
+            formatter={(value: number) => [`${value.toLocaleString()}원`, '시간대별 매출']}
           />
-          <Legend formatter={() => '누적 매출'} />
-          <Line type="monotone" dataKey="prefixSumPrice" name="누적 매출" stroke={Color.KIO_ORANGE} strokeWidth={2} activeDot={{ r: 8 }} />
+          <Legend formatter={() => '시간대별 매출'} />
+          <Line type="monotone" dataKey="price" name="시간대별 매출" stroke={Color.KIO_ORANGE} strokeWidth={2} activeDot={{ r: 8 }} />
         </LineChart>
       </ResponsiveContainer>
     </Container>

--- a/src/hooks/admin/useAdminOrder.tsx
+++ b/src/hooks/admin/useAdminOrder.tsx
@@ -83,8 +83,8 @@ function useAdminOrder(workspaceId: string | undefined) {
     });
   };
 
-  const fetchPrefixSumOrders = (props: { startDate: string; endDate: string; status?: OrderStatus }) => {
-    const response = adminApi.get('/orders/prefix-sum/price', { params: { ...props, workspaceId } }).catch((error) => {
+  const fetchOrderHourlyPrices = (props: { startDate: string; endDate: string; status?: OrderStatus }) => {
+    const response = adminApi.get('/orders/hourly/price', { params: { ...props, workspaceId } }).catch((error) => {
       console.log(error);
     });
     return response;
@@ -101,7 +101,7 @@ function useAdminOrder(workspaceId: string | undefined) {
     refundOrder,
     fetchWorkspaceTable,
     updateOrderProductCount,
-    fetchPrefixSumOrders,
+    fetchOrderHourlyPrices,
   };
 }
 

--- a/src/pages/admin/order/AdminOrderStatistics.tsx
+++ b/src/pages/admin/order/AdminOrderStatistics.tsx
@@ -113,7 +113,7 @@ function AdminOrderStatistics() {
     },
     {
       key: 'byPrice',
-      label: '매출 증가 추이',
+      label: '시간대별 매출',
       render: <OrderPriceStatistics startDate={parsedStartDate} endDate={parsedEndDate} status={status} />,
     },
   ];


### PR DESCRIPTION
## 📚 개요

- 주문 통계에서 "누적 매출 증가 추이"를 "시간대별 매출"로 변경했습니다.
- 새로 만들어진 api endpoint를 사용했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

![image](https://github.com/user-attachments/assets/1ac2888b-a836-43ba-ae7b-632ecc50349c)