### PR TITLE
FIX - 사파리 단일 QR 코드 다운로드 안되는 이슈 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "embla-carousel": "^8.5.2",
     "embla-carousel-autoplay": "^8.5.2",
     "embla-carousel-react": "^8.5.2",
-    "html-to-image": "^1.11.11",
     "http-status-codes": "^2.3.0",
     "jotai": "^2.12.5",
     "jsqr": "^1.4.0",

--- a/src/utils/qrCode.ts
+++ b/src/utils/qrCode.ts
@@ -1,0 +1,79 @@
+import { Color } from '@resources/colors';
+
+export const QR_IMAGE_SIZE = 150;
+export const GRID_SPACING = 20;
+export const COLUMNS_COUNT = 4;
+export const LABEL_SIZE = 35;
+
+export interface GridMetrics {
+  rowsCount: number;
+  cellStep: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+export function getQRCodeCanvases(container: HTMLDivElement): HTMLCanvasElement[] {
+  return Array.from(container.querySelectorAll<HTMLCanvasElement>('canvas'));
+}
+
+export function calculateGridMetrics(itemCount: number): GridMetrics {
+  const rows = Math.ceil(itemCount / COLUMNS_COUNT);
+  const step = QR_IMAGE_SIZE + GRID_SPACING;
+  return {
+    rowsCount: rows,
+    cellStep: step,
+    canvasWidth: COLUMNS_COUNT * QR_IMAGE_SIZE + (COLUMNS_COUNT - 1) * GRID_SPACING,
+    canvasHeight: rows * QR_IMAGE_SIZE + (rows - 1) * GRID_SPACING,
+  };
+}
+
+export function createOutputCanvas(width: number, height: number): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+export function initCanvasContext(ctx: CanvasRenderingContext2D, width: number, height: number) {
+  ctx.fillStyle = Color.WHITE;
+  ctx.fillRect(0, 0, width, height);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.font = 'bold 20px sans-serif';
+}
+
+export function drawQR(ctx: CanvasRenderingContext2D, qrCanvas: HTMLCanvasElement, tableNo: number, x: number, y: number) {
+  ctx.drawImage(qrCanvas, x, y, QR_IMAGE_SIZE, QR_IMAGE_SIZE);
+
+  const labelX = x + QR_IMAGE_SIZE - LABEL_SIZE;
+  const labelY = y + QR_IMAGE_SIZE - LABEL_SIZE;
+  ctx.fillStyle = Color.KIO_ORANGE;
+  ctx.fillRect(labelX, labelY, LABEL_SIZE, LABEL_SIZE);
+
+  ctx.fillStyle = Color.WHITE;
+  ctx.fillText(`${tableNo}`, labelX + LABEL_SIZE / 2, labelY + LABEL_SIZE / 2);
+}
+
+export function drawQRTiles(ctx: CanvasRenderingContext2D, qrCanvases: HTMLCanvasElement[], metrics: GridMetrics) {
+  qrCanvases.forEach((qrCanvas, idx) => {
+    const col = idx % COLUMNS_COUNT;
+    const row = Math.floor(idx / COLUMNS_COUNT);
+    const x = col * metrics.cellStep;
+    const y = row * metrics.cellStep;
+    drawQR(ctx, qrCanvas, idx + 1, x, y);
+  });
+}
+
+export function triggerDownload(canvas: HTMLCanvasElement, fileName: string) {
+  canvas.toBlob((blob) => {
+    if (!blob) return alert('이미지 생성 실패');
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3141,11 +3141,6 @@ hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-
   dependencies:
     react-is "^16.7.0"
 
-html-to-image@^1.11.11:
-  version "1.11.11"
-  resolved "https://registry.yarnpkg.com/html-to-image/-/html-to-image-1.11.11.tgz#c0f8a34dc9e4b97b93ff7ea286eb8562642ebbea"
-  integrity sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==
-
 http-status-codes@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.3.0.tgz#987fefb28c69f92a43aecc77feec2866349a8bfc"


### PR DESCRIPTION
## 📚 개요

### BEFORE
- `html-to-image`라이브러리를 사용한 단일 QR 코드는 사파리 브라우저에서 정상적으로 작동하지 않았습니다.

![3번 테이블 QR코드](https://github.com/user-attachments/assets/da8a1649-2f26-453c-a561-df53439a0061)

### TRY
- 우선 `html-to-image`라이브러리 버젼을 최신으로 업데이트 하고, [다음 이슈](https://github.com/bubkoo/html-to-image/issues/361)에 있는 방법들을 모두 시도해보았습니다.
- QR 코드는 정상적으로 보이지만, 여전히 폰트가 제대로 렌더링 되지 않는 이슈가 발생했습니다.

![18번 테이블 QR코드](https://github.com/user-attachments/assets/ec826782-6fa4-4bbc-bac1-21d8c0539045)

### SOLUTION
- 어차피 전체 QR 코드는 canvas api를 활용하여 직접 렌더링 한 뒤 다운로드 하고 있으므로, 해당 함수들을 이용하여 구현했습니다.

![5번 테이블 QR코드-4](https://github.com/user-attachments/assets/88792e84-4c54-49fd-b1b3-b485868534dc)

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)
- TRY에서 폰트가 제대로 렌더링 되지 않는 원인은 바로 `{fontSkip: true}` 속성으로 웹 폰트를 불러오는 걸 명시적으로 건너뛰었기 때문입니다. 만약 `{fontSkip: false}` 를 적용한다면 cdn을 통해 웹 폰트를 받아올 수 없다는 에러가 발생합니다. 
- 이는 Safari 브라우저의 강력한 [동일 출처 정책](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)때문입니다.

<img width="593" alt="image" src="https://github.com/user-attachments/assets/62bd260b-8ce3-44ab-b7ba-181385d78972" />

- 반면에 크롬은 정상적으로 잘 받아와지는 모습입니다.

<img width="817" alt="스크린샷 2025-06-24 오후 8 51 18" src="https://github.com/user-attachments/assets/43a13361-35ba-4cf9-80ed-9034245b1cd3" />

- 결론적으로 Safari에서는 웹 폰트 로딩이 막혀 텍스트 레이아웃이 깨지는 문제가 발생합니다. 이 문제를 해결하기 위해, 웹 폰트 의존성 없이 이미지를 생성하는 기존의 'Canvas QR 코드 다운로드' 기능을 그대로 활용하기로 결정했습니다
- QR코드를 canvas에 그리고 다운로드 하는 함수들을 utils 폴더에 별도의 파일로 분리했습니다.