### PR TITLE
EDIT - 테이블 관리 페이지 수정

### DIFF
--- a/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
+++ b/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
@@ -132,21 +132,21 @@ function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProp
 
   const formattedNowTime = formatKoreanTime(new Date().toISOString()) || '시간 없음';
 
-  useEffect(() => {
-    const getTableOrders = () => {
-      if (orderSessionId) {
-        fetchOrderSession(orderSessionId)
-          .then((response) => {
-            setTableOrders(response.data);
-          })
-          .catch((error) => {
-            console.error('Error fetching table orders:', error);
-          });
-      } else {
-        setTableOrders([]);
-      }
-    };
+  const getTableOrders = () => {
+    if (orderSessionId) {
+      fetchOrderSession(orderSessionId)
+        .then((response) => {
+          setTableOrders(response.data);
+        })
+        .catch((error) => {
+          console.error('Error fetching table orders:', error);
+        });
+    } else {
+      setTableOrders([]);
+    }
+  };
 
+  useEffect(() => {
     getTableOrders();
 
     const intervalId = setInterval(getTableOrders, defaultInterval);
@@ -156,7 +156,7 @@ function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProp
   return (
     <Container>
       <Header>
-        <RefreshSection>
+        <RefreshSection onClick={getTableOrders}>
           <NowTimeLabel>{formattedNowTime}</NowTimeLabel>
           <RefreshIcon />
         </RefreshSection>

--- a/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
+++ b/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
@@ -131,12 +131,12 @@ interface TableOrderListProps {
   orderSessionId: number;
 }
 
+const formattedNowTime = formatKoreanTime(new Date().toISOString()) || '시간 없음';
+
 function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProps) {
   const { isModalOpen, openModal, closeModal } = useModal();
   const { fetchOrderSession } = useAdminOrder(String(workspaceId));
   const [tableOrders, setTableOrders] = useState<Order[]>([]);
-
-  const formattedNowTime = formatKoreanTime(new Date().toISOString()) || '시간 없음';
 
   const getTableOrders = () => {
     if (orderSessionId) {

--- a/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
+++ b/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
@@ -9,7 +9,7 @@ import { formatKoreanTime } from '@utils/FormatDate';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import TableOrderDetailModal from '../modal/TableOrderDetailModal';
 
-const defaultInterval = 5000;
+const defaultInterval = 60000;
 
 const Container = styled.div`
   border: 1px solid #ececec;

--- a/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
+++ b/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
@@ -2,7 +2,7 @@ import { Order, OrderProduct } from '@@types/index';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
-import { RiSearchLine } from '@remixicon/react';
+import { RiSearchLine, RiResetRightFill } from '@remixicon/react';
 import { Color } from '@resources/colors';
 import useModal from '@hooks/useModal';
 import { formatKoreanTime } from '@utils/FormatDate';
@@ -29,7 +29,30 @@ const Header = styled.div`
   font-size: 15px;
   font-weight: 600;
   border-bottom: 1px solid #ececec;
-  ${colFlex({ justify: 'center', align: 'center' })};
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+`;
+
+const RefreshSection = styled.div`
+  ${rowFlex({ align: 'center' })};
+  gap: 10px;
+  cursor: pointer;
+  &:hover {
+    color: ${Color.KIO_ORANGE};
+  }
+`;
+
+const NowTimeLabel = styled.div``;
+
+const RefreshIcon = styled(RiResetRightFill)`
+  width: 20px;
+  height: 20px;
+`;
+
+const HeaderTitle = styled.div`
+  text-align: center;
 `;
 
 const OrderListContainer = styled.div`
@@ -107,6 +130,8 @@ function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProp
   const { fetchOrderSession } = useAdminOrder(String(workspaceId));
   const [tableOrders, setTableOrders] = useState<Order[]>([]);
 
+  const formattedNowTime = formatKoreanTime(new Date().toISOString()) || '시간 없음';
+
   useEffect(() => {
     const getTableOrders = () => {
       if (orderSessionId) {
@@ -130,7 +155,14 @@ function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProp
 
   return (
     <Container>
-      <Header>주문 내역</Header>
+      <Header>
+        <RefreshSection>
+          <NowTimeLabel>{formattedNowTime}</NowTimeLabel>
+          <RefreshIcon />
+        </RefreshSection>
+        <HeaderTitle>주문 내역</HeaderTitle>
+        <div />
+      </Header>
       <OrderListContainer>
         <OrderHeader>
           <HeaderCell>번호</HeaderCell>

--- a/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
+++ b/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
@@ -64,7 +64,7 @@ const OrderListContainer = styled.div`
 
 const OrderHeader = styled.div`
   display: grid;
-  grid-template-columns: 0.5fr 1.5fr 2fr 1fr 1fr 0.5fr;
+  grid-template-columns: 0.5fr 1.2fr 1.8fr 1fr 1fr 1fr 0.5fr;
   padding: 10px;
   background-color: ${Color.LIGHT_GREY};
   border-bottom: 1px solid #ececec;
@@ -75,7 +75,7 @@ const OrderHeader = styled.div`
 
 const OrderRow = styled.div`
   display: grid;
-  grid-template-columns: 0.5fr 1.5fr 2fr 1fr 1fr 0.5fr;
+  grid-template-columns: 0.5fr 1.2fr 1.8fr 1fr 1fr 1fr 0.5fr;
   padding: 10px;
   border-bottom: 1px solid ${Color.LIGHT_GREY};
   text-align: center;
@@ -118,6 +118,12 @@ const formatProductNames = (orderProducts: OrderProduct[] | undefined) => {
     return orderProducts[0].productName;
   }
   return `${orderProducts[0].productName} 외 ${orderProducts.length - 1}개`;
+};
+
+const ORDER_STATUS_MAP = {
+  NOT_PAID: '주문 완료',
+  PAID: '결제 완료',
+  SERVED: '서빙 완료',
 };
 
 interface TableOrderListProps {
@@ -170,6 +176,7 @@ function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProp
           <HeaderCell>상품명</HeaderCell>
           <HeaderCell>입금자명</HeaderCell>
           <HeaderCell>금액</HeaderCell>
+          <HeaderCell>주문상태</HeaderCell>
           <HeaderCell>보기</HeaderCell>
         </OrderHeader>
         <OrderItem>
@@ -184,6 +191,7 @@ function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProp
                   <OrderCell>{formatProductNames(order.orderProducts)}</OrderCell>
                   <OrderCell>{order.customerName}</OrderCell>
                   <OrderCell>{`${order.totalPrice.toLocaleString()}원`}</OrderCell>
+                  <OrderCell>{ORDER_STATUS_MAP[order.status as keyof typeof ORDER_STATUS_MAP] || order.status}</OrderCell>
                   <ActionCell>
                     <SearchIcon onClick={openModal} />
                   </ActionCell>

--- a/src/components/admin/order/table-manage/setting/TableCount.tsx
+++ b/src/components/admin/order/table-manage/setting/TableCount.tsx
@@ -121,7 +121,7 @@ function TableCount() {
           <PlusButton onClick={handlePlusClick} />
         </InputContainer>
         <RoundedAppButton size={'130px'} fontSize={'16px'} onClick={handleConfirm}>
-          확인
+          저장
         </RoundedAppButton>
       </Content>
     </Container>

--- a/src/components/admin/order/table-manage/setting/TableTimeLimit.tsx
+++ b/src/components/admin/order/table-manage/setting/TableTimeLimit.tsx
@@ -114,7 +114,7 @@ function TableTimeLimit() {
   const handleConfirm = () => {
     updateWorkspaceOrderSetting(workspaceId, isTimeLimited, timeLimitMinutes)
       .then(() => {
-        alert(`테이블 시간 제한이 ${isTimeLimited ? '활성화' : '비활성화'}되었습니다.`);
+        alert(`테이블 시간 제한이 ${isTimeLimited ? `${formatTime(timeLimitMinutes)}으로 설정` : '비활성화'}되었습니다.`);
       })
       .catch(() => {
         alert('테이블 시간 제한 설정에 실패했습니다. 다시 시도해주세요.');
@@ -143,7 +143,7 @@ function TableTimeLimit() {
           <PlusButton disabled={!isTimeLimited} onClick={handlePlusClick} />
         </InputContainer>
         <RoundedAppButton size={'130px'} fontSize={'16px'} onClick={handleConfirm}>
-          확인
+          저장
         </RoundedAppButton>
       </Content>
     </Container>

--- a/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
+++ b/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
@@ -61,7 +61,7 @@ function TableSessionControler({ tables, workspaceId, orderSessionId, currentExp
   });
 
   const nowTable = tables.find((table) => table.tableNumber === tableNumber);
-  const isTableUsing = nowTable?.orderSession;
+  const isDisabledSession = !nowTable?.orderSession;
 
   return (
     <Container>
@@ -72,7 +72,7 @@ function TableSessionControler({ tables, workspaceId, orderSessionId, currentExp
           handleDecrement={handleDecrement}
           handleIncrement={handleIncrement}
           handleTimeChange={handleTimeChange}
-          disabled={!isTableUsing}
+          disabled={isDisabledSession}
         />
         <TableTimeButtons
           handleDecreaseTime={handleDecreaseTime}
@@ -80,7 +80,7 @@ function TableSessionControler({ tables, workspaceId, orderSessionId, currentExp
           handleEndSession={handleEndSession}
           handleStartSession={handleStartSession}
           orderSessionId={orderSessionId}
-          disabled={!isTableUsing}
+          disabled={isDisabledSession}
         />
       </Content>
     </Container>

--- a/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
+++ b/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
@@ -3,10 +3,13 @@ import useAdminTable from '@hooks/admin/useAdminTable';
 import { Color } from '@resources/colors';
 import { colFlex } from '@styles/flexStyles';
 import { dateConverter } from '@utils/FormatDate';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import TableTimeControler from './TableTimeControler';
 import TableTimeButtons from './TableTimeButtons';
 import { Table } from '@@types/index';
+
+const SESSION_STORAGE_KEY = 'selectedTimeLimit';
+const DEFAULT_TIME_LIMIT = 10;
 
 const Container = styled.div`
   border: 1px solid #ececec;
@@ -37,7 +40,6 @@ const Content = styled.div`
 
 interface TableSessionControlerProps {
   tables: Table[];
-  timeLimit: number;
   workspaceId: string | undefined;
   orderSessionId: number | undefined;
   currentExpectedEndAt: string | undefined;
@@ -45,16 +47,20 @@ interface TableSessionControlerProps {
   refetchTable: () => void;
 }
 
-function TableSessionControler({
-  tables,
-  timeLimit,
-  workspaceId,
-  orderSessionId,
-  currentExpectedEndAt,
-  tableNumber,
-  refetchTable,
-}: TableSessionControlerProps) {
-  const [selectedTimeLimit, setSelectedTimeLimit] = useState<number>(timeLimit);
+function TableSessionControler({ tables, workspaceId, orderSessionId, currentExpectedEndAt, tableNumber, refetchTable }: TableSessionControlerProps) {
+  const [selectedTimeLimit, setSelectedTimeLimit] = useState<number>(() => {
+    const storedTime = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (storedTime) {
+      return parseInt(storedTime, 10);
+    }
+    sessionStorage.setItem(SESSION_STORAGE_KEY, DEFAULT_TIME_LIMIT.toString());
+    return DEFAULT_TIME_LIMIT;
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, selectedTimeLimit.toString());
+  }, [selectedTimeLimit]);
+
   const { updateSessionEndTime, finishTableSession, startTableSession } = useAdminTable(workspaceId);
   const nowTable = tables.find((table) => table.tableNumber === tableNumber);
   const isTableUsing = nowTable?.orderSession;

--- a/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
+++ b/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
@@ -6,6 +6,7 @@ import { dateConverter } from '@utils/FormatDate';
 import { useState } from 'react';
 import TableTimeControler from './TableTimeControler';
 import TableTimeButtons from './TableTimeButtons';
+import { Table } from '@@types/index';
 
 const Container = styled.div`
   border: 1px solid #ececec;
@@ -35,6 +36,7 @@ const Content = styled.div`
 `;
 
 interface TableSessionControlerProps {
+  tables: Table[];
   timeLimit: number;
   workspaceId: string | undefined;
   orderSessionId: number | undefined;
@@ -43,10 +45,19 @@ interface TableSessionControlerProps {
   refetchTable: () => void;
 }
 
-function TableSessionControler({ timeLimit, workspaceId, orderSessionId, currentExpectedEndAt, tableNumber, refetchTable }: TableSessionControlerProps) {
+function TableSessionControler({
+  tables,
+  timeLimit,
+  workspaceId,
+  orderSessionId,
+  currentExpectedEndAt,
+  tableNumber,
+  refetchTable,
+}: TableSessionControlerProps) {
   const [selectedTimeLimit, setSelectedTimeLimit] = useState<number>(timeLimit);
   const { updateSessionEndTime, finishTableSession, startTableSession } = useAdminTable(workspaceId);
-
+  const nowTable = tables.find((table) => table.tableNumber === tableNumber);
+  const isTableUsing = nowTable?.orderSession;
   const handleApiAndRefetch = (apiCall: Promise<any>) => {
     apiCall.then((res) => {
       if (res) refetchTable();
@@ -128,6 +139,7 @@ function TableSessionControler({ timeLimit, workspaceId, orderSessionId, current
           handleDecrement={handleDecrement}
           handleIncrement={handleIncrement}
           handleTimeChange={handleTimeChange}
+          disabled={!isTableUsing}
         />
         <TableTimeButtons
           handleDecreaseTime={handleDecreaseTime}
@@ -135,6 +147,7 @@ function TableSessionControler({ timeLimit, workspaceId, orderSessionId, current
           handleEndSession={handleEndSession}
           handleStartSession={handleStartSession}
           orderSessionId={orderSessionId}
+          disabled={!isTableUsing}
         />
       </Content>
     </Container>

--- a/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
+++ b/src/components/admin/order/table-manage/timer/TableSessionControler.tsx
@@ -5,6 +5,8 @@ import TableTimeControler from './TableTimeControler';
 import TableTimeButtons from './TableTimeButtons';
 import { Table } from '@@types/index';
 import { useTableSession } from '@hooks/admin/useTableSession';
+import { useAtomValue } from 'jotai';
+import { adminWorkspaceAtom } from 'src/jotai/admin/atoms';
 
 const Container = styled.div`
   border: 1px solid #ececec;
@@ -60,15 +62,17 @@ function TableSessionControler({ tables, workspaceId, orderSessionId, currentExp
     refetchTable,
   });
 
+  const workspace = useAtomValue(adminWorkspaceAtom);
   const nowTable = tables.find((table) => table.tableNumber === tableNumber);
   const isDisabledSession = !nowTable?.orderSession;
+  const defaultSessionTimeLimit = String(workspace?.workspaceSetting?.orderSessionTimeLimitMinutes);
 
   return (
     <Container>
       <Header>상태 변경</Header>
       <Content>
         <TableTimeControler
-          timeLimit={selectedTimeLimit}
+          timeLimit={isDisabledSession ? defaultSessionTimeLimit : selectedTimeLimit}
           handleDecrement={handleDecrement}
           handleIncrement={handleIncrement}
           handleTimeChange={handleTimeChange}

--- a/src/components/admin/order/table-manage/timer/TableTimeButtons.tsx
+++ b/src/components/admin/order/table-manage/timer/TableTimeButtons.tsx
@@ -17,22 +17,23 @@ const BottomRow = styled.div`
   width: 100%;
 `;
 
-const Button = styled.button<{ isFullWidth?: boolean }>`
-  background: ${Color.KIO_ORANGE};
-  color: ${Color.WHITE};
+const Button = styled.button<{ isFullWidth?: boolean; disabled?: boolean }>`
+  background: ${({ disabled }) => (disabled ? Color.LIGHT_GREY : Color.KIO_ORANGE)};
+  color: ${({ disabled }) => (disabled ? Color.GREY : Color.WHITE)};
   border: none;
   border-radius: 40px;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   font-family: 'LINE Seed Sans KR', sans-serif;
   font-size: 12px;
   font-weight: 700;
   padding: 8px;
   width: ${({ isFullWidth }) => (isFullWidth ? '100%' : '81px')};
   height: 30px;
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   ${rowFlex({ justify: 'center', align: 'center' })}
 
   &:hover {
-    background: #ff9d50;
+    background: ${({ disabled }) => (disabled ? Color.LIGHT_GREY : '#ff9d50')};
   }
 `;
 
@@ -42,18 +43,23 @@ interface TableTimeButtonsProps {
   handleEndSession: () => void;
   handleStartSession: () => void;
   orderSessionId?: number;
+  disabled?: boolean;
 }
 
-function TableTimeButtons({ handleDecreaseTime, handleIncreaseTime, handleEndSession, handleStartSession, orderSessionId }: TableTimeButtonsProps) {
+function TableTimeButtons({ handleDecreaseTime, handleIncreaseTime, handleEndSession, handleStartSession, orderSessionId, disabled }: TableTimeButtonsProps) {
   return (
     <Container>
       <TopRow>
-        <Button onClick={handleDecreaseTime}>감소</Button>
-        <Button onClick={handleIncreaseTime}>증가</Button>
+        <Button disabled={disabled} onClick={disabled ? undefined : handleDecreaseTime}>
+          감소
+        </Button>
+        <Button disabled={disabled} onClick={disabled ? undefined : handleIncreaseTime}>
+          증가
+        </Button>
       </TopRow>
       <BottomRow>
         {orderSessionId ? (
-          <Button isFullWidth onClick={handleEndSession}>
+          <Button isFullWidth disabled={disabled} onClick={disabled ? undefined : handleEndSession}>
             사용종료
           </Button>
         ) : (

--- a/src/components/admin/order/table-manage/timer/TableTimeButtons.tsx
+++ b/src/components/admin/order/table-manage/timer/TableTimeButtons.tsx
@@ -17,23 +17,29 @@ const BottomRow = styled.div`
   width: 100%;
 `;
 
-const Button = styled.button<{ isFullWidth?: boolean; disabled?: boolean }>`
-  background: ${({ disabled }) => (disabled ? Color.LIGHT_GREY : Color.KIO_ORANGE)};
-  color: ${({ disabled }) => (disabled ? Color.GREY : Color.WHITE)};
+const Button = styled.button<{ isFullWidth?: boolean }>`
+  background: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
   border: none;
   border-radius: 40px;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  cursor: pointer;
   font-family: 'LINE Seed Sans KR', sans-serif;
   font-size: 12px;
   font-weight: 700;
   padding: 8px;
   width: ${({ isFullWidth }) => (isFullWidth ? '100%' : '81px')};
   height: 30px;
-  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   ${rowFlex({ justify: 'center', align: 'center' })}
 
   &:hover {
     background: ${({ disabled }) => (disabled ? Color.LIGHT_GREY : '#ff9d50')};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    background: ${Color.LIGHT_GREY};
+    color: ${Color.GREY};
   }
 `;
 
@@ -50,16 +56,16 @@ function TableTimeButtons({ handleDecreaseTime, handleIncreaseTime, handleEndSes
   return (
     <Container>
       <TopRow>
-        <Button disabled={disabled} onClick={disabled ? undefined : handleDecreaseTime}>
+        <Button disabled={disabled} onClick={handleDecreaseTime}>
           감소
         </Button>
-        <Button disabled={disabled} onClick={disabled ? undefined : handleIncreaseTime}>
+        <Button disabled={disabled} onClick={handleIncreaseTime}>
           증가
         </Button>
       </TopRow>
       <BottomRow>
         {orderSessionId ? (
-          <Button isFullWidth disabled={disabled} onClick={disabled ? undefined : handleEndSession}>
+          <Button isFullWidth disabled={disabled} onClick={handleEndSession}>
             사용종료
           </Button>
         ) : (

--- a/src/components/admin/order/table-manage/timer/TableTimeControler.tsx
+++ b/src/components/admin/order/table-manage/timer/TableTimeControler.tsx
@@ -19,36 +19,42 @@ const InputWrapper = styled.div`
   ${rowFlex({ justify: 'center', align: 'center' })};
 `;
 
-const Input = styled.input`
+const MinusButton = styled(RiSubtractFill)<{ disabled?: boolean }>`
+  width: 20px;
+  height: 20px;
+  color: ${({ disabled }) => (disabled ? Color.GREY : Color.KIO_ORANGE)};
+  background-color: ${Color.WHITE};
+  border-radius: 50%;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
+`;
+
+const PlusButton = styled(RiAddFill)<{ disabled?: boolean }>`
+  width: 20px;
+  height: 20px;
+  color: ${({ disabled }) => (disabled ? Color.GREY : Color.WHITE)};
+  background-color: ${({ disabled }) => (disabled ? Color.LIGHT_GREY : Color.KIO_ORANGE)};
+  border-radius: 50%;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
+`;
+
+const Input = styled.input<{ disabled?: boolean }>`
   width: 90px;
   text-align: center;
   background: none;
   border: none;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'text')};
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   &:focus {
     outline: none;
   }
 `;
 
-const Unit = styled.span`
+const Unit = styled.span<{ disabled?: boolean }>`
   font-size: 14px;
-`;
-
-const MinusButton = styled(RiSubtractFill)`
-  width: 20px;
-  height: 20px;
-  color: ${Color.KIO_ORANGE};
-  background-color: ${Color.WHITE};
-  border-radius: 50%;
-  cursor: pointer;
-`;
-
-const PlusButton = styled(RiAddFill)`
-  width: 20px;
-  height: 20px;
-  color: ${Color.WHITE};
-  background-color: ${Color.KIO_ORANGE};
-  border-radius: 50%;
-  cursor: pointer;
+  color: ${({ disabled }) => (disabled ? Color.GREY : 'inherit')};
+  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
 `;
 
 interface TableTimeControlerProps {
@@ -56,17 +62,18 @@ interface TableTimeControlerProps {
   handleDecrement: () => void;
   handleIncrement: () => void;
   handleTimeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
 }
 
-function TableTimeControler({ timeLimit, handleDecrement, handleIncrement, handleTimeChange }: TableTimeControlerProps) {
+function TableTimeControler({ timeLimit, handleDecrement, handleIncrement, handleTimeChange, disabled }: TableTimeControlerProps) {
   return (
     <Container>
-      <MinusButton onClick={handleDecrement} />
+      <MinusButton disabled={disabled} onClick={disabled ? undefined : handleDecrement} />
       <InputWrapper>
-        <Input type="number" value={timeLimit} onChange={handleTimeChange} />
-        <Unit>분</Unit>
+        <Input type="number" value={timeLimit} onChange={disabled ? undefined : handleTimeChange} disabled={disabled} />
+        <Unit disabled={disabled}>분</Unit>
       </InputWrapper>
-      <PlusButton onClick={handleIncrement} />
+      <PlusButton disabled={disabled} onClick={disabled ? undefined : handleIncrement} />
     </Container>
   );
 }

--- a/src/components/admin/order/table-manage/timer/TableTimeControler.tsx
+++ b/src/components/admin/order/table-manage/timer/TableTimeControler.tsx
@@ -39,15 +39,20 @@ const PlusButton = styled(RiAddFill)<{ disabled?: boolean }>`
   opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
 `;
 
-const Input = styled.input<{ disabled?: boolean }>`
+const Input = styled.input`
   width: 90px;
   text-align: center;
   background: none;
   border: none;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'text')};
-  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
+  cursor: text;
+
   &:focus {
     outline: none;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 `;
 
@@ -62,18 +67,18 @@ interface TableTimeControlerProps {
   handleDecrement: () => void;
   handleIncrement: () => void;
   handleTimeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  disabled?: boolean;
+  disabled: boolean;
 }
 
 function TableTimeControler({ timeLimit, handleDecrement, handleIncrement, handleTimeChange, disabled }: TableTimeControlerProps) {
   return (
     <Container>
-      <MinusButton disabled={disabled} onClick={disabled ? undefined : handleDecrement} />
+      <MinusButton disabled={disabled} onClick={handleDecrement} />
       <InputWrapper>
-        <Input value={timeLimit} onChange={disabled ? undefined : handleTimeChange} disabled={disabled} />
+        <Input value={timeLimit} disabled={disabled} onChange={handleTimeChange} />
         <Unit disabled={disabled}>분</Unit>
       </InputWrapper>
-      <PlusButton disabled={disabled} onClick={disabled ? undefined : handleIncrement} />
+      <PlusButton disabled={disabled} onClick={handleIncrement} />
     </Container>
   );
 }

--- a/src/components/admin/order/table-manage/timer/TableTimeControler.tsx
+++ b/src/components/admin/order/table-manage/timer/TableTimeControler.tsx
@@ -58,7 +58,7 @@ const Unit = styled.span<{ disabled?: boolean }>`
 `;
 
 interface TableTimeControlerProps {
-  timeLimit: number;
+  timeLimit: string;
   handleDecrement: () => void;
   handleIncrement: () => void;
   handleTimeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -70,7 +70,7 @@ function TableTimeControler({ timeLimit, handleDecrement, handleIncrement, handl
     <Container>
       <MinusButton disabled={disabled} onClick={disabled ? undefined : handleDecrement} />
       <InputWrapper>
-        <Input type="number" value={timeLimit} onChange={disabled ? undefined : handleTimeChange} disabled={disabled} />
+        <Input value={timeLimit} onChange={disabled ? undefined : handleTimeChange} disabled={disabled} />
         <Unit disabled={disabled}>분</Unit>
       </InputWrapper>
       <PlusButton disabled={disabled} onClick={disabled ? undefined : handleIncrement} />

--- a/src/hooks/admin/useTableSession.tsx
+++ b/src/hooks/admin/useTableSession.tsx
@@ -6,7 +6,6 @@ const SESSION_STORAGE_KEY = 'selectedTimeLimit';
 const DEFAULT_TIME_LIMIT = 10;
 const MINUTES_TO_MILLISECONDS = 60 * 1000;
 const NUMBER_ONLY_REGEX = /[^0-9]/g;
-const MINIMUM_TIME_LIMIT = 0;
 
 interface UseTableSessionProps {
   workspaceId: string | undefined;
@@ -17,13 +16,13 @@ interface UseTableSessionProps {
 }
 
 export function useTableSession({ workspaceId, currentExpectedEndAt, orderSessionId, tableNumber, refetchTable }: UseTableSessionProps) {
-  const [selectedTimeLimit, setSelectedTimeLimit] = useState<number>(() => {
+  const [selectedTimeLimit, setSelectedTimeLimit] = useState<string>(() => {
     const storedTime = sessionStorage.getItem(SESSION_STORAGE_KEY);
     if (storedTime) {
-      return parseInt(storedTime, 10);
+      return storedTime;
     }
     sessionStorage.setItem(SESSION_STORAGE_KEY, DEFAULT_TIME_LIMIT.toString());
-    return DEFAULT_TIME_LIMIT;
+    return DEFAULT_TIME_LIMIT.toString();
   });
 
   useEffect(() => {
@@ -90,15 +89,15 @@ export function useTableSession({ workspaceId, currentExpectedEndAt, orderSessio
     const value = e.target.value;
     const sanitizedValue = value.replace(NUMBER_ONLY_REGEX, '');
 
-    setSelectedTimeLimit(parseInt(sanitizedValue, 10));
+    setSelectedTimeLimit(sanitizedValue);
   };
 
   const handleIncrement = () => {
-    setSelectedTimeLimit((prevTimeLimit) => (prevTimeLimit || MINIMUM_TIME_LIMIT) + 1);
+    setSelectedTimeLimit((prevTimeLimit) => (Number(prevTimeLimit || '0') + 1).toString());
   };
 
   const handleDecrement = () => {
-    setSelectedTimeLimit((prevTimeLimit) => Math.max(MINIMUM_TIME_LIMIT, prevTimeLimit - 1));
+    setSelectedTimeLimit((prevTimeLimit) => Math.max(0, Number(prevTimeLimit) - 1).toString());
   };
 
   return {

--- a/src/hooks/admin/useTableSession.tsx
+++ b/src/hooks/admin/useTableSession.tsx
@@ -1,0 +1,114 @@
+import { useState, useEffect } from 'react';
+import useAdminTable from '@hooks/admin/useAdminTable';
+import { dateConverter } from '@utils/FormatDate';
+
+const SESSION_STORAGE_KEY = 'selectedTimeLimit';
+const DEFAULT_TIME_LIMIT = 10;
+const MINUTES_TO_MILLISECONDS = 60 * 1000;
+const NUMBER_ONLY_REGEX = /[^0-9]/g;
+const MINIMUM_TIME_LIMIT = 0;
+
+interface UseTableSessionProps {
+  workspaceId: string | undefined;
+  currentExpectedEndAt: string | undefined;
+  orderSessionId: number | undefined;
+  tableNumber?: number;
+  refetchTable: () => void;
+}
+
+export function useTableSession({ workspaceId, currentExpectedEndAt, orderSessionId, tableNumber, refetchTable }: UseTableSessionProps) {
+  const [selectedTimeLimit, setSelectedTimeLimit] = useState<number>(() => {
+    const storedTime = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (storedTime) {
+      return parseInt(storedTime, 10);
+    }
+    sessionStorage.setItem(SESSION_STORAGE_KEY, DEFAULT_TIME_LIMIT.toString());
+    return DEFAULT_TIME_LIMIT;
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, selectedTimeLimit.toString());
+  }, [selectedTimeLimit]);
+
+  const { updateSessionEndTime, finishTableSession, startTableSession } = useAdminTable(workspaceId);
+
+  const handleApiAndRefetch = (apiCall: Promise<any>) => {
+    apiCall.then((res) => {
+      if (res) refetchTable();
+    });
+  };
+
+  const handleDecreaseTime = () => {
+    if (!currentExpectedEndAt || !orderSessionId) {
+      alert('세션 ID가 없습니다. 세션을 시작해주세요.');
+      return;
+    }
+
+    const timeToDecrease = Number(selectedTimeLimit);
+    if (isNaN(timeToDecrease) || timeToDecrease <= 0) {
+      alert('단축 시간을 올바르게 입력해주세요.');
+      return;
+    }
+
+    const currentEndDate = new Date(currentExpectedEndAt);
+    const newEndDate = new Date(currentEndDate.getTime() - timeToDecrease * MINUTES_TO_MILLISECONDS);
+    const newEndDateString = dateConverter(newEndDate);
+
+    handleApiAndRefetch(updateSessionEndTime(orderSessionId, newEndDateString));
+  };
+
+  const handleIncreaseTime = () => {
+    if (!currentExpectedEndAt || !orderSessionId) {
+      alert('세션 ID가 없습니다. 세션을 시작해주세요.');
+      return;
+    }
+
+    const timeToExtend = Number(selectedTimeLimit);
+    if (isNaN(timeToExtend) || timeToExtend <= 0) {
+      alert('연장 시간을 올바르게 입력해주세요.');
+      return;
+    }
+
+    const currentEndDate = new Date(currentExpectedEndAt);
+    const newEndDate = new Date(currentEndDate.getTime() + timeToExtend * MINUTES_TO_MILLISECONDS);
+    const newEndDateString = dateConverter(newEndDate);
+
+    handleApiAndRefetch(updateSessionEndTime(orderSessionId, newEndDateString));
+  };
+
+  const handleEndSession = () => {
+    if (!orderSessionId || !tableNumber) return;
+    handleApiAndRefetch(finishTableSession(orderSessionId, tableNumber));
+  };
+
+  const handleStartSession = () => {
+    if (!tableNumber) return;
+    handleApiAndRefetch(startTableSession(tableNumber));
+  };
+
+  const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    const sanitizedValue = value.replace(NUMBER_ONLY_REGEX, '');
+
+    setSelectedTimeLimit(parseInt(sanitizedValue, 10));
+  };
+
+  const handleIncrement = () => {
+    setSelectedTimeLimit((prevTimeLimit) => (prevTimeLimit || MINIMUM_TIME_LIMIT) + 1);
+  };
+
+  const handleDecrement = () => {
+    setSelectedTimeLimit((prevTimeLimit) => Math.max(MINIMUM_TIME_LIMIT, prevTimeLimit - 1));
+  };
+
+  return {
+    selectedTimeLimit,
+    handleDecrement,
+    handleIncrement,
+    handleTimeChange,
+    handleDecreaseTime,
+    handleIncreaseTime,
+    handleEndSession,
+    handleStartSession,
+  };
+}

--- a/src/hooks/admin/useTableSession.tsx
+++ b/src/hooks/admin/useTableSession.tsx
@@ -21,12 +21,19 @@ export function useTableSession({ workspaceId, currentExpectedEndAt, orderSessio
     if (storedTime) {
       return storedTime;
     }
-    sessionStorage.setItem(SESSION_STORAGE_KEY, DEFAULT_TIME_LIMIT.toString());
     return DEFAULT_TIME_LIMIT.toString();
   });
 
   useEffect(() => {
-    sessionStorage.setItem(SESSION_STORAGE_KEY, selectedTimeLimit.toString());
+    const existingValue = sessionStorage.getItem(SESSION_STORAGE_KEY);
+
+    if (!existingValue) {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, selectedTimeLimit);
+    }
+  }, []);
+
+  useEffect(() => {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, selectedTimeLimit);
   }, [selectedTimeLimit]);
 
   const { updateSessionEndTime, finishTableSession, startTableSession } = useAdminTable(workspaceId);

--- a/src/hooks/admin/useTableSession.tsx
+++ b/src/hooks/admin/useTableSession.tsx
@@ -5,7 +5,44 @@ import { dateConverter } from '@utils/FormatDate';
 const SESSION_STORAGE_KEY = 'selectedTimeLimit';
 const DEFAULT_TIME_LIMIT = 10;
 const MINUTES_TO_MILLISECONDS = 60 * 1000;
-const NUMBER_ONLY_REGEX = /[^0-9]/g;
+
+/**
+ * 시간 입력값을 검증하고 정제하는 함수
+ *
+ * @param {string} value - 사용자가 입력한 원본 문자열
+ * @returns {string} 정제된 시간 값 (1-999 범위의 숫자 문자열 또는 빈 문자열)
+ *
+ * @description
+ * 다음 규칙을 적용하여 입력값을 정제합니다:
+ * 1. 숫자가 아닌 모든 문자 제거
+ * 2. 앞에 오는 0들 제거 (예: "007" → "7")
+ * 3. "0"만 입력된 경우 빈 문자열로 변환
+ * 4. 최대 3자리까지만 허용 (999분 제한)
+ * 5. 빈 문자열은 그대로 유지 (사용자가 모든 내용을 지운 경우)
+ *
+ * @example
+ * sanitizeTimeInput("01") // "1"
+ * sanitizeTimeInput("007") // "7"
+ * sanitizeTimeInput("0") // ""
+ * sanitizeTimeInput("abc123") // "123"
+ * sanitizeTimeInput("1234") // "123"
+ * sanitizeTimeInput("") // ""
+ */
+const sanitizeTimeInput = (value: string): string => {
+  let sanitized = value.replace(/[^0-9]/g, '');
+
+  if (sanitized === '') return '';
+
+  sanitized = sanitized.replace(/^0+/, '');
+
+  if (sanitized === '') return '';
+
+  if (sanitized.length > 3) {
+    sanitized = sanitized.slice(0, 3);
+  }
+
+  return sanitized;
+};
 
 interface UseTableSessionProps {
   workspaceId: string | undefined;
@@ -93,18 +130,30 @@ export function useTableSession({ workspaceId, currentExpectedEndAt, orderSessio
   };
 
   const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    const sanitizedValue = value.replace(NUMBER_ONLY_REGEX, '');
-
+    const sanitizedValue = sanitizeTimeInput(e.target.value);
     setSelectedTimeLimit(sanitizedValue);
   };
 
   const handleIncrement = () => {
-    setSelectedTimeLimit((prevTimeLimit) => (Number(prevTimeLimit || '0') + 1).toString());
+    setSelectedTimeLimit((prevTimeLimit) => {
+      if (prevTimeLimit === '') {
+        return DEFAULT_TIME_LIMIT.toString();
+      }
+
+      const currentValue = Number(prevTimeLimit);
+      return (currentValue + 1).toString();
+    });
   };
 
   const handleDecrement = () => {
-    setSelectedTimeLimit((prevTimeLimit) => Math.max(0, Number(prevTimeLimit) - 1).toString());
+    setSelectedTimeLimit((prevTimeLimit) => {
+      if (prevTimeLimit === '') {
+        return DEFAULT_TIME_LIMIT.toString();
+      }
+
+      const currentValue = Number(prevTimeLimit);
+      return Math.max(1, currentValue - 1).toString();
+    });
   };
 
   return {

--- a/src/pages/admin/table/AdminOrderTable.tsx
+++ b/src/pages/admin/table/AdminOrderTable.tsx
@@ -103,6 +103,7 @@ function AdminOrderTable() {
                 currentExpectedEndAt={selectedTable.orderSession?.expectedEndAt}
                 tableNumber={selectedTable.tableNumber}
                 refetchTable={fetchTables}
+                tables={tables}
               />
               <TableQRCode workspaceId={workspaceId} selectedTable={selectedTable} />
             </DetailHeader>

--- a/src/pages/admin/table/AdminOrderTable.tsx
+++ b/src/pages/admin/table/AdminOrderTable.tsx
@@ -10,10 +10,8 @@ import styled from '@emotion/styled';
 import useAdminWorkspace from '@hooks/admin/useAdminWorkspace';
 import { Color } from '@resources/colors';
 import { colFlex } from '@styles/flexStyles';
-import { useAtomValue } from 'jotai';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { adminWorkspaceAtom } from 'src/jotai/admin/atoms';
 
 const Container = styled.div`
   width: 100%;
@@ -52,7 +50,6 @@ const FallbackText = styled.div`
 function AdminOrderTable() {
   const navigate = useNavigate();
   const { workspaceId } = useParams<{ workspaceId: string }>();
-  const workspaceSetting = useAtomValue(adminWorkspaceAtom).workspaceSetting;
 
   const [searchParams] = useSearchParams();
   const tableNo = searchParams.get('tableNo');
@@ -97,7 +94,6 @@ function AdminOrderTable() {
             <DetailHeader>
               <TableElapsedTimer createdAt={selectedTable.orderSession?.createdAt} expectedEndAt={selectedTable.orderSession?.expectedEndAt} />
               <TableSessionControler
-                timeLimit={workspaceSetting.orderSessionTimeLimitMinutes}
                 workspaceId={workspaceId}
                 orderSessionId={selectedTable.orderSession?.id}
                 currentExpectedEndAt={selectedTable.orderSession?.expectedEndAt}


### PR DESCRIPTION
## 📚 개요

- 테이블 관리 페이지에 대해 자잘한 수정을 진행했습니다.

### 리프레시 버튼 추가
- 기존에는 setTimeInterval로 5초 간격으로 데이터를 fetch해오고 있었습니다.(React Query로 빨리 바꿔야지,,)
- 새로고침 버튼을 통해 데이터를 refetch하는 로직을 추가했습니다.

<img width="101" height="32" alt="스크린샷 2025-08-02 오후 8 15 26" src="https://github.com/user-attachments/assets/4e96fc05-a72c-4db8-a8b4-9ccefdc2e9af" />

### 주문 상태 추가
- 들어온 주문의 상태들도 확인할 수 있도록 '주문상태' 필드를 추가했습니다.
<img width="656" height="85" alt="스크린샷 2025-08-02 오후 8 10 25" src="https://github.com/user-attachments/assets/b5016566-0f72-4eeb-ac22-ed80adbf02bf" />

### 스토리지를 이용하여 동적인 기본 테이블 별 시간제한 적용
- 세션이 시작되지 않은 테이블은 '상태변경' input에  주점 기본 세션 리밋이 보입니다.
- 세션이 시작되면 '상태변경' input에 10분을 기본으로 보여집니다.(해당 값은 세션 스토리지를 이용합니다.)

<img width="1467" height="822" alt="스크린샷 2025-08-02 오후 8 13 31" src="https://github.com/user-attachments/assets/236bc784-78a4-4afc-b6f7-25c806758665" />

<img width="1467" height="822" alt="스크린샷 2025-08-02 오후 8 13 41" src="https://github.com/user-attachments/assets/fcd1d831-dde1-4edf-921a-1a1d79cc2a62" />

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- 기존 `TableSessionControler`의 로직들을 `useTableSession`라는 별도의 커스텀 훅으로 분리했습니다.