### PR TITLE
FIX - 실시간 테이블 관리 페이지 주문 상세 내역 정보 불일치 문제 해결

### DIFF
--- a/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
+++ b/src/components/admin/order/table-manage/list/AdminTableOrderList.tsx
@@ -1,13 +1,12 @@
-import { Order, OrderProduct } from '@@types/index';
+import { Order } from '@@types/index';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
-import { RiSearchLine, RiResetRightFill } from '@remixicon/react';
+import { RiResetRightFill } from '@remixicon/react';
 import { Color } from '@resources/colors';
-import useModal from '@hooks/useModal';
 import { formatKoreanTime } from '@utils/FormatDate';
 import { colFlex, rowFlex } from '@styles/flexStyles';
-import TableOrderDetailModal from '../modal/TableOrderDetailModal';
+import OrderRowItem from './OrderRowItem';
 
 const defaultInterval = 60000;
 
@@ -73,15 +72,6 @@ const OrderHeader = styled.div`
   font-weight: 600;
 `;
 
-const OrderRow = styled.div`
-  display: grid;
-  grid-template-columns: 0.5fr 1.2fr 1.8fr 1fr 1fr 1fr 0.5fr;
-  padding: 10px;
-  border-bottom: 1px solid ${Color.LIGHT_GREY};
-  text-align: center;
-  align-items: center;
-`;
-
 const OrderItem = styled.div`
   overflow-y: auto;
   flex-grow: 1;
@@ -95,38 +85,9 @@ const OrderFallback = styled.div`
   ${colFlex({ justify: 'center', align: 'center' })};
 `;
 
-const SearchIcon = styled(RiSearchLine)`
-  color: ${Color.GREY};
-  cursor: pointer;
-`;
-
 const HeaderCell = styled.div`
   color: ${Color.GREY};
 `;
-
-const OrderCell = styled.div`
-  color: ${Color.GREY};
-`;
-
-const ActionCell = styled.div`
-  ${rowFlex({ justify: 'center', align: 'center' })};
-`;
-
-const formatProductNames = (orderProducts: OrderProduct[] | undefined) => {
-  if (!orderProducts || orderProducts.length === 0) {
-    return '상품 없음';
-  }
-  if (orderProducts.length === 1) {
-    return orderProducts[0].productName;
-  }
-  return `${orderProducts[0].productName} 외 ${orderProducts.length - 1}개`;
-};
-
-const ORDER_STATUS_MAP = {
-  NOT_PAID: '주문 완료',
-  PAID: '결제 완료',
-  SERVED: '서빙 완료',
-};
 
 interface TableOrderListProps {
   workspaceId: number | undefined | null;
@@ -136,7 +97,6 @@ interface TableOrderListProps {
 const formattedNowTime = formatKoreanTime(new Date().toISOString()) || '시간 없음';
 
 function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProps) {
-  const { isModalOpen, openModal, closeModal } = useModal();
   const { fetchOrderSession } = useAdminOrder(String(workspaceId));
   const [tableOrders, setTableOrders] = useState<Order[]>([]);
 
@@ -181,28 +141,7 @@ function AdminTableOrderList({ workspaceId, orderSessionId }: TableOrderListProp
           <HeaderCell>보기</HeaderCell>
         </OrderHeader>
         <OrderItem>
-          {tableOrders.length > 0 ? (
-            tableOrders.map((order: Order) => {
-              const formattedStartTime = formatKoreanTime(order.createdAt) || '시간 없음';
-
-              return (
-                <OrderRow key={order.id}>
-                  <OrderCell>{order.id}</OrderCell>
-                  <OrderCell>{formattedStartTime}</OrderCell>
-                  <OrderCell>{formatProductNames(order.orderProducts)}</OrderCell>
-                  <OrderCell>{order.customerName}</OrderCell>
-                  <OrderCell>{`${order.totalPrice.toLocaleString()}원`}</OrderCell>
-                  <OrderCell>{ORDER_STATUS_MAP[order.status as keyof typeof ORDER_STATUS_MAP] || order.status}</OrderCell>
-                  <ActionCell>
-                    <SearchIcon onClick={openModal} />
-                  </ActionCell>
-                  <TableOrderDetailModal order={order} isModalOpen={isModalOpen} closeModal={closeModal} />
-                </OrderRow>
-              );
-            })
-          ) : (
-            <OrderFallback>주문 없음</OrderFallback>
-          )}
+          {tableOrders.length > 0 ? tableOrders.map((order: Order) => <OrderRowItem key={order.id} order={order} />) : <OrderFallback>주문 없음</OrderFallback>}
         </OrderItem>
       </OrderListContainer>
     </Container>

--- a/src/components/admin/order/table-manage/list/OrderRowItem.tsx
+++ b/src/components/admin/order/table-manage/list/OrderRowItem.tsx
@@ -1,0 +1,74 @@
+import { Order } from '@@types/index';
+import { RiSearchLine } from '@remixicon/react';
+import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
+import { rowFlex } from '@styles/flexStyles';
+import { formatKoreanTime } from '@utils/FormatDate';
+import useModal from '@hooks/useModal';
+import TableOrderDetailModal from '../modal/TableOrderDetailModal';
+
+const OrderRow = styled.div`
+  display: grid;
+  grid-template-columns: 0.5fr 1.2fr 1.8fr 1fr 1fr 1fr 0.5fr;
+  padding: 10px;
+  border-bottom: 1px solid ${Color.LIGHT_GREY};
+  text-align: center;
+  align-items: center;
+`;
+
+const OrderCell = styled.div`
+  color: ${Color.GREY};
+`;
+
+const ActionCell = styled.div`
+  ${rowFlex({ justify: 'center', align: 'center' })};
+`;
+
+const SearchIcon = styled(RiSearchLine)`
+  color: ${Color.GREY};
+  cursor: pointer;
+`;
+
+const ORDER_STATUS_MAP = {
+  NOT_PAID: '주문 완료',
+  PAID: '결제 완료',
+  SERVED: '서빙 완료',
+};
+
+const formatProductNames = (orderProducts: any[] | undefined) => {
+  if (!orderProducts || orderProducts.length === 0) {
+    return '상품 없음';
+  }
+  if (orderProducts.length === 1) {
+    return orderProducts[0].productName;
+  }
+  return `${orderProducts[0].productName} 외 ${orderProducts.length - 1}개`;
+};
+
+interface OrderRowItemProps {
+  order: Order;
+}
+
+function OrderRowItem({ order }: OrderRowItemProps) {
+  const { isModalOpen, openModal, closeModal } = useModal();
+  const formattedStartTime = formatKoreanTime(order.createdAt) || '시간 없음';
+
+  return (
+    <>
+      <OrderRow>
+        <OrderCell>{order.orderNumber}</OrderCell>
+        <OrderCell>{formattedStartTime}</OrderCell>
+        <OrderCell>{formatProductNames(order.orderProducts)}</OrderCell>
+        <OrderCell>{order.customerName}</OrderCell>
+        <OrderCell>{`${order.totalPrice.toLocaleString()}원`}</OrderCell>
+        <OrderCell>{ORDER_STATUS_MAP[order.status as keyof typeof ORDER_STATUS_MAP] || order.status}</OrderCell>
+        <ActionCell>
+          <SearchIcon onClick={openModal} />
+        </ActionCell>
+      </OrderRow>
+      <TableOrderDetailModal order={order} isModalOpen={isModalOpen} closeModal={closeModal} />
+    </>
+  );
+}
+
+export default OrderRowItem;


### PR DESCRIPTION
## 📚 개요

- 실시간 테이블 관리 페이지에서 주문 상세 내역(모달) 정보 불일치 문제를 해결했습니다.
### BEFORE

https://github.com/user-attachments/assets/542df6dc-d658-4750-bd64-5b06c9893e56


### AFTER

https://github.com/user-attachments/assets/061e1e56-15a6-46fe-b593-7701f5b8ef75



## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

### 문제 원인
- 해당 문제 원인은 React의 클로저 특성과 모달 상태 공유 때문입니다.
- tableOrders.map()내부에서 렌더링되는 각 OrderRowItem의 TableOrderDetailModal이 모두 **동일한 모달 상태(isModalOpen)**를 공유하고 있었습니다. 
- React의 렌더링 과정에서 map 함수가 실행될 때, 모든 모달 컴포넌트가 마지막으로 처리된 order 객체를 클로저로 참조하게 되어 어떤 "보기" 버튼을 클릭해도 항상 마지막 주문의 정보가 표시되는 문제가 발생했습니다.
```typescript
// 문제가 있던 코드 구조
{tableOrders.map((order) => (
  <OrderRowItem key={order.id} order={order} />
  // ↳ 내부에서 TableOrderDetailModal이 같은 모달 상태를 공유
))}
``` 

### 문제 해결
- 각 주문별로 독립적인 모달 상태를 관리하도록 OrderRowItem 컴포넌트 내부에서 개별 useModal 훅을 사용하는 방식으로 수정했습니다.
- 이를 통해 각 주문 행마다 고유한 모달 상태(isModalOpen, openModal, closeModal)를 가지게 되어, 특정 주문의 "보기" 버튼 클릭 시 해당 주문의 정보만 정확히 모달에 표시되도록 개선했습니다.
```typescript
// OrderRowItem 내부에서 각각 독립적인 모달 상태 관리
function OrderRowItem({ order }: { order: Order }) {
  const { isModalOpen, openModal, closeModal } = useModal(); // 각 행별 독립 상태
  
  return (
    <>
      <OrderRow>
        {/* ... */}
        <SearchIcon onClick={openModal} />
      </OrderRow>
      <TableOrderDetailModal 
        isOpen={isModalOpen} 
        onClose={closeModal} 
        order={order} // 정확한 order 정보 전달
      />
``` 