### PR TITLE
EDIT - 카테고리 배지 스크롤 offset 수정

### DIFF
--- a/src/components/user/order/CategoryBadgesContainer.tsx
+++ b/src/components/user/order/CategoryBadgesContainer.tsx
@@ -41,6 +41,7 @@ interface CategoryBadgesContainerProps {
 
 function CategoryBadgesContainer({ productCategories, productsByCategory }: CategoryBadgesContainerProps) {
   const duration = 400;
+  const offset = -100;
   const isScrolling = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -70,7 +71,7 @@ function CategoryBadgesContainer({ productCategories, productsByCategory }: Cate
               to={`category_${category.id}`}
               spy={true}
               smooth={true}
-              offset={-350}
+              offset={offset}
               duration={duration}
               onSetActive={() => {
                 categoryClick(category.id);
@@ -89,7 +90,7 @@ function CategoryBadgesContainer({ productCategories, productsByCategory }: Cate
           to="category_default"
           spy={true}
           smooth={true}
-          offset={-350}
+          offset={offset}
           duration={duration}
           onSetActive={() => {
             categoryClick(-1);


### PR DESCRIPTION
## 📚 개요

- 기존에는 scroll이 화면 중앙으로 됐지만, 화면 상단으로 되게끔 수정했습니다.
- 마지막 element는 제대로 표시 안되는 이슈가 있지만, 이게 더 직관적이라 생각되어서 수정했습니다.
- 상수 선언했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

### BEFORE

https://github.com/user-attachments/assets/50b1b276-f7b9-4f07-bf67-cbbfe03bc867

### AFTER


https://github.com/user-attachments/assets/4b33ae81-f601-489e-b348-e16dc437ce56

