### PR TITLE
EDIT - userWorkspaceAtom을 기존atomWithStorage에서 atom으로 수정

### DIFF
--- a/src/jotai/user/atoms.ts
+++ b/src/jotai/user/atoms.ts
@@ -1,12 +1,10 @@
 import { defaultUserOrderValue, defaultWorkspaceValue } from '@@types/defaultValues';
 import { Order, OrderProductBase, ProductCategory, Workspace } from '@@types/index';
 import { atom } from 'jotai';
-import { atomWithReset, atomWithStorage } from 'jotai/utils';
+import { atomWithReset } from 'jotai/utils';
 import { adminCategoriesAtom } from '../admin/atoms';
 
-export const userWorkspaceAtom = atomWithStorage<Workspace>('userWorkspace', defaultWorkspaceValue, undefined, {
-  getOnInit: true,
-});
+export const userWorkspaceAtom = atom<Workspace>(defaultWorkspaceValue);
 export const userOrderAtom = atom<Order>(defaultUserOrderValue);
 export const userOrderBasketAtom = atomWithReset<OrderProductBase[]>([]);
 export const userCategoriesAtom = atom<ProductCategory[]>((get) => get(adminCategoriesAtom));


### PR DESCRIPTION
## 📚 개요
- #329 해당 PR에서 추가한 로그 출력 결과를 확인해보니, 간헐적으로 `userWorkspaceAtom`의 값을 기본값으로 가져와는 버그가 발생했습니다.

<img width="372" height="878" alt="스크린샷 2025-10-01 오전 3 25 06" src="https://github.com/user-attachments/assets/017075c4-494b-4c34-812f-db17cd890059" />

- 이 부분이 스토리지의 값을 읽어와 atom을 초기화 하는 atomWithStorage와 연관이 있다 판단하여, userWorkspaceAtom의 속성을 기존atomWithStorage에서 atom으로 수정했습니다.
- 해당 조치를 취한 후에도 동일한 에러가 발생하는지 지속적인 모니터링이 필요하므로, 기존 로그 출력 코드 및 로직은 유지합니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)
