### PR TITLE
EDIT - 전체 QR 코드 다운로드 패딩 추가

### DIFF
--- a/src/resources/data/popupData.tsx
+++ b/src/resources/data/popupData.tsx
@@ -18,7 +18,7 @@ export const popupDatas: PopupData[] = [
   {
     popupId: 1,
     title: '키오스쿨 사용 인터뷰에 참여해주세요!',
-    expireDate: dayjs().set('year', 2025).set('month', 9).set('date', 30).toDate(),
+    expireDate: dayjs().set('year', 2025).set('month', 8).set('date', 30).toDate(),
     children: <PopupContent1 />,
   },
 ];

--- a/src/utils/qrCode.ts
+++ b/src/utils/qrCode.ts
@@ -4,6 +4,7 @@ export const QR_IMAGE_SIZE = 150;
 export const GRID_SPACING = 20;
 export const COLUMNS_COUNT = 4;
 export const LABEL_SIZE = 35;
+export const CANVAS_PADDING = 20;
 
 export interface GridMetrics {
   rowsCount: number;
@@ -22,8 +23,8 @@ export function calculateGridMetrics(itemCount: number): GridMetrics {
   return {
     rowsCount: rows,
     cellStep: step,
-    canvasWidth: COLUMNS_COUNT * QR_IMAGE_SIZE + (COLUMNS_COUNT - 1) * GRID_SPACING,
-    canvasHeight: rows * QR_IMAGE_SIZE + (rows - 1) * GRID_SPACING,
+    canvasWidth: COLUMNS_COUNT * QR_IMAGE_SIZE + (COLUMNS_COUNT - 1) * GRID_SPACING + CANVAS_PADDING * 2,
+    canvasHeight: rows * QR_IMAGE_SIZE + (rows - 1) * GRID_SPACING + CANVAS_PADDING * 2,
   };
 }
 
@@ -58,8 +59,8 @@ export function drawQRTiles(ctx: CanvasRenderingContext2D, qrCanvases: HTMLCanva
   qrCanvases.forEach((qrCanvas, idx) => {
     const col = idx % COLUMNS_COUNT;
     const row = Math.floor(idx / COLUMNS_COUNT);
-    const x = col * metrics.cellStep;
-    const y = row * metrics.cellStep;
+    const x = col * metrics.cellStep + CANVAS_PADDING;
+    const y = row * metrics.cellStep + CANVAS_PADDING;
     drawQR(ctx, qrCanvas, idx + 1, x, y);
   });
 }


### PR DESCRIPTION
## 📚 개요

- 전체 QR 코드 다운로드하고 실제 출력시, QR코드 3 모퉁이에 있는 위치 지정 패턴이 잘릴 수 있는 위험이 있어, 이를 해결하고자 QR코드의 패딩을 추가했습니다.

<img width="517" height="353" alt="스크린샷 2025-10-03 오후 8 12 00" src="https://github.com/user-attachments/assets/e7b898f6-8dc4-4888-8873-9fc18cd504fb" />

#### BEFORE
<img width="1980" height="4020" alt="콤공 게임 센-타!!!!-모든-QR코드 (2)" src="https://github.com/user-attachments/assets/03a5716a-23b2-4861-aeec-8a55d4136309" />

#### AFTER
<img width="2100" height="4140" alt="콤공 게임 센-타!!!!-모든-QR코드 (3)" src="https://github.com/user-attachments/assets/808a0a82-8f08-4adc-a9b8-c7f3cda879c2" />


- 인터뷰 팝업 만료일을 수정하여 더이상 뜨지 않도록 했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

리뷰가 비교적 꼼꼼히 이루어져야할 부분이나 파일을 여기다 적어주거나
해당 로직에 직접 코멘트를 달아도 좋습니다