### PR TITLE
REFACTOR - 카테고리 관리 typo 조정

### DIFF
--- a/src/components/admin/product-category/CategoryItem.tsx
+++ b/src/components/admin/product-category/CategoryItem.tsx
@@ -24,12 +24,12 @@ const CategoryContentsContainer = styled.div`
 `;
 
 const CategoryName = styled.label`
-  font-size: 18px;
+  font-size: 16px;
   width: 50%;
 `;
 
 const DefaultCategoryNotice = styled.label`
-  font-size: 14px;
+  font-size: 12px;
   color: #8d8d8d;
 `;
 

--- a/src/pages/admin/AdminProductCategories.tsx
+++ b/src/pages/admin/AdminProductCategories.tsx
@@ -29,7 +29,7 @@ const CategoriesItemContainer = styled.div`
 `;
 
 const SectionTitle = styled.div`
-  font-size: 20px;
+  font-size: 16px;
   font-weight: 700;
   color: #464a4d;
   padding-bottom: 15px;
@@ -46,7 +46,7 @@ const CategoryInput = styled.input`
   border: none;
   border-bottom: 1px solid #e8eef2;
   padding: 12px 4px;
-  font-size: 18px;
+  font-size: 16px;
   box-sizing: border-box;
 
   &:focus {
@@ -107,7 +107,7 @@ function AdminProductCategories() {
         </CategoriesItemContainer>
 
         <CategoriesButtonContainer className={'categories-button-container'}>
-          <NewCommonButton onClick={saveCategory} size="md">
+          <NewCommonButton onClick={saveCategory} size="sm">
             편집 완료
           </NewCommonButton>
         </CategoriesButtonContainer>


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

카테고리 관리 페이지의 text 및 버튼 크기를 조정했습니다.

**BEFORE**

<img width="1458" height="748" alt="image" src="https://github.com/user-attachments/assets/032a6cae-ef7e-44c8-9b46-91a77ab5f413" />


**AFTER**

<img width="1444" height="751" alt="image" src="https://github.com/user-attachments/assets/4474313a-0ca0-4d45-9e3e-c9863777b431" />


## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)
