### PR TITLE
FIX - Timeline grid 렌더링 오류 수정

### DIFF
--- a/src/components/admin/order/timeline/TimelineGrid.tsx
+++ b/src/components/admin/order/timeline/TimelineGrid.tsx
@@ -66,20 +66,31 @@ const TrackColumn = styled.div`
   ${colFlex()}
 `;
 
-const TrackRow = styled.div<{ totalHours: number }>`
+const TrackRow = styled.div`
   height: 50px;
   position: relative;
   border-bottom: 1px solid ${TIMELINE_COLORS.BORDER};
   border-right: 1px solid ${TIMELINE_COLORS.BORDER};
   box-sizing: border-box;
   background-color: white;
-  background-image: repeating-linear-gradient(
-    to right,
-    ${TIMELINE_COLORS.BORDER} 0px,
-    ${TIMELINE_COLORS.BORDER} 1px,
-    transparent 1px,
-    transparent calc(100% / ${({ totalHours }) => totalHours * 2})
-  );
+`;
+
+const TimeGridLayer = styled.div<{ segmentCount: number }>`
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: grid;
+  grid-template-columns: repeat(${({ segmentCount }) => segmentCount}, minmax(0, 1fr));
+  pointer-events: none;
+`;
+
+const TimeGridSegment = styled.div`
+  border-left: 1px solid ${TIMELINE_COLORS.BORDER_CARD};
+  box-sizing: border-box;
+
+  &[data-hour='true'] {
+    border-left-color: ${TIMELINE_COLORS.BORDER};
+  }
 `;
 
 const EmptyMessage = styled.div`
@@ -148,6 +159,7 @@ function TimelineGrid({ sessions, tableCount, selectedDate, currentTime, minPric
   );
 
   const sessionsByTable = useMemo(() => groupBy(sessions, 'tableNumber'), [sessions]);
+  const timeSegments = useMemo(() => Array.from({ length: totalHours * 2 }, (_, i) => i), [totalHours]);
 
   if (tableCount === 0) {
     return <EmptyMessage>워크스페이스에 테이블이 없습니다</EmptyMessage>;
@@ -175,7 +187,12 @@ function TimelineGrid({ sessions, tableCount, selectedDate, currentTime, minPric
           {tableNumbers.map((tableNo) => {
             const tableSessions = sessionsByTable[tableNo] || [];
             return (
-              <TrackRow key={tableNo} totalHours={totalHours}>
+              <TrackRow key={tableNo}>
+                <TimeGridLayer segmentCount={timeSegments.length} aria-hidden="true">
+                  {timeSegments.map((segment) => (
+                    <TimeGridSegment key={segment} data-hour={segment % 2 === 0} />
+                  ))}
+                </TimeGridLayer>
                 {tableSessions.map((session) => (
                   <SessionBar
                     key={session.id}


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

Timeline 그리드 라인이 보이지 않는 오류를 해결하였습니다.

**BEFORE**

<img width="1304" height="821" alt="image" src="https://github.com/user-attachments/assets/3e0c6e52-3487-4006-9c97-3b16dd3875cf" />

오류 원인은 `TrackRow`의 세로 시간 간격선을 CSS `repeating-linear-gradient`로 동적으로 그려서 발생하였습니다.

- 기존: 배경 이미지의 반복 패턴으로 1px 선을 그림. 너비를 계산하는 과정에서 브라우저가 반올림 하고, 생략되는 선이 발생
- 수정: 실제 DOM grid 칸의 `border-left`로 1px 선을 그림

**AFTER**
<img width="1426" height="723" alt="image" src="https://github.com/user-attachments/assets/017d5560-0bed-442c-9b14-9ad12806b8e9" />


## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)