### PR TITLE
REFACTOR - 전체 레이아웃 간격 조정

### DIFF
--- a/src/components/admin/my-info/MyInfoContent.tsx
+++ b/src/components/admin/my-info/MyInfoContent.tsx
@@ -11,7 +11,7 @@ const Container = styled.div`
 `;
 
 const CardsContainer = styled.div`
-  width: 100%;
+  width: 95%;
   gap: 10px;
   ${rowFlex({ justify: 'center', align: 'center' })}
 `;

--- a/src/components/admin/workspace/WorkspaceContent.tsx
+++ b/src/components/admin/workspace/WorkspaceContent.tsx
@@ -6,20 +6,33 @@ import { RiArrowRightSLine, RiDeleteBinFill } from '@remixicon/react';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
 import { expandButtonStyle } from '@styles/buttonStyles';
+import { mobileMediaQuery, tabletMediaQuery } from '@styles/globalStyles';
 import { useNavigate } from 'react-router-dom';
 import { getAdminWorkspacePath } from '@constants/routes';
 import { formatDate } from '@utils/formatDate';
 import NewCommonButton from '@components/common/button/NewCommonButton';
 
 const Container = styled.div`
+  width: 100%;
   gap: 29px;
-  ${rowFlex()}
+  flex-wrap: wrap;
+  ${rowFlex({ justify: 'center', align: 'center' })}
+
+  ${tabletMediaQuery} {
+    gap: 20px;
+  }
+
+  ${mobileMediaQuery} {
+    gap: 16px;
+  }
 `;
 
 const WorkspaceContainer = styled.div`
   box-sizing: border-box;
-  width: 380px;
+  width: 100%;
+  max-width: 380px;
   height: 350px;
+  flex: 1 1 340px;
   border-radius: 16px;
   padding: 24px 20px;
   background: ${Color.KIO_ORANGE};
@@ -79,9 +92,10 @@ const Description = styled.li`
 
 interface Props {
   workspaces: Workspace[];
+  children?: React.ReactNode;
 }
 
-function WorkspaceContent({ workspaces }: Props) {
+function WorkspaceContent({ workspaces, children }: Props) {
   const navigate = useNavigate();
   const { leaveWorkspace } = useAdminUser();
   const { ConfirmModal, confirm } = useConfirm({
@@ -133,6 +147,7 @@ function WorkspaceContent({ workspaces }: Props) {
           </NewCommonButton>
         </WorkspaceContainer>
       ))}
+      {children}
       <ConfirmModal />
     </Container>
   );

--- a/src/components/admin/workspace/WorkspaceContent.tsx
+++ b/src/components/admin/workspace/WorkspaceContent.tsx
@@ -6,7 +6,6 @@ import { RiArrowRightSLine, RiDeleteBinFill } from '@remixicon/react';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
 import { expandButtonStyle } from '@styles/buttonStyles';
-import { mobileMediaQuery, tabletMediaQuery } from '@styles/globalStyles';
 import { useNavigate } from 'react-router-dom';
 import { getAdminWorkspacePath } from '@constants/routes';
 import { formatDate } from '@utils/formatDate';
@@ -14,25 +13,16 @@ import NewCommonButton from '@components/common/button/NewCommonButton';
 
 const Container = styled.div`
   width: 100%;
-  gap: 29px;
-  flex-wrap: wrap;
+  gap: 20px;
   ${rowFlex({ justify: 'center', align: 'center' })}
-
-  ${tabletMediaQuery} {
-    gap: 20px;
-  }
-
-  ${mobileMediaQuery} {
-    gap: 16px;
-  }
 `;
 
 const WorkspaceContainer = styled.div`
   box-sizing: border-box;
-  width: 100%;
+  width: calc((100% - 40px) / 3);
   max-width: 380px;
+  min-width: 0;
   height: 350px;
-  flex: 1 1 340px;
   border-radius: 16px;
   padding: 24px 20px;
   background: ${Color.KIO_ORANGE};

--- a/src/components/common/workspace/AddWorkspace.tsx
+++ b/src/components/common/workspace/AddWorkspace.tsx
@@ -6,8 +6,10 @@ import { Color } from '@resources/colors';
 
 const AddWorkspaceContainer = styled.form`
   cursor: pointer;
-  width: 380px;
+  width: 100%;
+  max-width: 380px;
   height: 350px;
+  flex: 1 1 340px;
   border: 1px solid #e8eef2;
   border-radius: 16px;
   background: ${Color.WHITE};

--- a/src/components/common/workspace/AddWorkspace.tsx
+++ b/src/components/common/workspace/AddWorkspace.tsx
@@ -6,10 +6,10 @@ import { Color } from '@resources/colors';
 
 const AddWorkspaceContainer = styled.form`
   cursor: pointer;
-  width: 100%;
+  width: calc((100% - 40px) / 3);
   max-width: 380px;
+  min-width: 0;
   height: 350px;
-  flex: 1 1 340px;
   border: 1px solid #e8eef2;
   border-radius: 16px;
   background: ${Color.WHITE};

--- a/src/pages/admin/AdminAccount.tsx
+++ b/src/pages/admin/AdminAccount.tsx
@@ -10,8 +10,7 @@ import { useLocation } from 'react-router-dom';
 
 const AccountContainer = styled.div`
   width: 100%;
-  // TODO : 디자인이 생각보다 너무 길어서 자체적으로 줄임
-  height: 600px;
+  height: 520px;
   gap: 15px;
   ${rowFlex({ justify: 'space-between' })};
 `;

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -5,15 +5,21 @@ import useAdminUser from '@hooks/admin/useAdminUser';
 import AppContainer from '@components/common/container/AppContainer';
 import AddWorkspace from '@components/common/workspace/AddWorkspace';
 import WorkspaceContent from '@components/admin/workspace/WorkspaceContent';
-import { rowFlex } from '@styles/flexStyles';
+import { colFlex } from '@styles/flexStyles';
 import { useAtomValue } from 'jotai';
 import { adminUserAtom, adminWorkspacesAtom } from '@jotai/admin/atoms';
 import AppFaqButton from '@components/common/button/AppFaqButton';
 import KioSchoolGuideYoutubeContent, { KIOSCHOOL_GUIDE_YOUTUBE_TOAST_COOKIE } from '@components/admin/home/KioSchoolGuideYoutubeContent';
 import { useNavigate } from 'react-router-dom';
 import { ADMIN_ROUTES } from '@constants/routes';
+import styled from '@emotion/styled';
 
 const YOUTUBE_TOAST_ID = 'youtube-guide-toast';
+
+const Container = styled.div`
+  width: 95%;
+  ${colFlex({ align: 'center' })}
+`;
 
 function AdminHome() {
   const navigate = useNavigate();
@@ -52,14 +58,15 @@ function AdminHome() {
   }, [cookies]);
 
   return (
-    <AppContainer useFlex={rowFlex({ justify: 'center', align: 'center' })} customGap={'30px'}>
-      <>
-        <WorkspaceContent workspaces={workspaces} />
-        {Array.from({ length: addWorkspaceNumber }).map((_, i) => (
-          <AddWorkspace key={i} workspaces={workspaces} />
-        ))}
+    <AppContainer useFlex={colFlex({ justify: 'center', align: 'center' })} customGap={'30px'}>
+      <Container>
+        <WorkspaceContent workspaces={workspaces}>
+          {Array.from({ length: addWorkspaceNumber }).map((_, i) => (
+            <AddWorkspace key={i} workspaces={workspaces} />
+          ))}
+        </WorkspaceContent>
         <AppFaqButton />
-      </>
+      </Container>
     </AppContainer>
   );
 }

--- a/src/pages/admin/AdminProduct.tsx
+++ b/src/pages/admin/AdminProduct.tsx
@@ -29,7 +29,7 @@ const ProductAddButtonContainer = styled.div`
 
 const ProductContainer = styled.div`
   box-sizing: border-box;
-  width: 100%;
+  width: 95%;
   padding: 18px 30px;
   gap: 10px;
   border: 1px solid #e8eef2;

--- a/src/pages/admin/AdminProductCategories.tsx
+++ b/src/pages/admin/AdminProductCategories.tsx
@@ -89,7 +89,7 @@ function AdminProductCategories() {
   };
 
   return (
-    <AppContainer useFlex={colFlex({ justify: 'center', align: 'center' })}>
+    <AppContainer useFlex={colFlex({ justify: 'start', align: 'center' })}>
       <Container className={'admin-product-categories-container'}>
         <CategoriesInputContainer className={'categories-input-container'}>
           <SectionTitle>등록할 카테고리명</SectionTitle>

--- a/src/pages/admin/AdminWorkspaceEdit.tsx
+++ b/src/pages/admin/AdminWorkspaceEdit.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom';
 import AppContainer from '@components/common/container/AppContainer';
 import styled from '@emotion/styled';
 import useAdminWorkspace from '@hooks/admin/useAdminWorkspace';
-import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { WorkspaceImage } from '@@types/index';
 import { extractImageIdsAndFiles, initWorkspaceImages, removeAndPushNull } from '@utils/workspaceEdit';
@@ -12,19 +11,8 @@ import { adminWorkspaceAtom } from '@jotai/admin/atoms';
 import { useAtomValue } from 'jotai';
 import { css } from '@emotion/react';
 import NewCommonButton from '@components/common/button/NewCommonButton';
-
-const inputStyle = `
-  box-sizing: border-box;
-  border-radius: 15px;
-  border: none;
-  padding: 12px 20px;
-  resize: none;
-  border: 1px solid #e8eef2;
-  &:focus {
-    outline: none;
-    border: 1px solid ${Color.KIO_ORANGE};
-  }
-`;
+import NewAppInput from '@components/common/input/NewAppInput';
+import NewAppTextarea from '@components/common/input/NewAppTextarea';
 
 const containerStyle = css`
   width: 95%;
@@ -49,11 +37,6 @@ const TitleContainer = styled.div`
   ${containerStyle}
 `;
 
-const TitleInput = styled.input`
-  width: 100%;
-  ${inputStyle}
-`;
-
 const ImageContainer = styled.div`
   ${containerStyle}
 `;
@@ -64,25 +47,17 @@ const ImageInputContainer = styled.div`
 `;
 
 const DescriptionContainer = styled.div`
-  height: 150px;
   ${containerStyle}
-`;
-
-const DescriptionInput = styled.textarea`
-  width: 100%;
-  height: 130px;
-  ${inputStyle}
 `;
 
 const NoticeContainer = styled.div`
-  height: 150px;
   ${containerStyle}
 `;
 
-const NoticeInput = styled.textarea`
-  width: 100%;
-  height: 130px;
-  ${inputStyle}
+const ButtonContainer = styled.div`
+  width: 95%;
+  margin-top: 20px;
+  ${rowFlex({ justify: 'center', align: 'center' })}
 `;
 
 function AdminWorkspaceEdit() {
@@ -159,8 +134,7 @@ function AdminWorkspaceEdit() {
     <AppContainer useFlex={colFlex({ justify: 'center' })} customWidth={'1000px'}>
       <ContentContainer>
         <TitleContainer>
-          <Label>주점명</Label>
-          <TitleInput ref={titleRef} defaultValue={workspace?.name || ''} />
+          <NewAppInput label="주점명" ref={titleRef} defaultValue={workspace?.name || ''} width="100%" />
         </TitleContainer>
         <ImageContainer>
           <Label>대표 사진</Label>
@@ -169,16 +143,16 @@ function AdminWorkspaceEdit() {
           </ImageInputContainer>
         </ImageContainer>
         <DescriptionContainer>
-          <Label>주점 설명</Label>
-          <DescriptionInput ref={descriptionRef} defaultValue={workspace?.description || ''} />
+          <NewAppTextarea label="주점 설명" ref={descriptionRef} defaultValue={workspace?.description || ''} width="100%" />
         </DescriptionContainer>
         <NoticeContainer>
-          <Label>공지 사항</Label>
-          <NoticeInput ref={noticeRef} defaultValue={workspace?.notice || ''} />
+          <NewAppTextarea label="공지 사항" ref={noticeRef} defaultValue={workspace?.notice || ''} width="100%" />
         </NoticeContainer>
-        <NewCommonButton size={'sm'} onClick={handleSubmit}>
-          편집 완료
-        </NewCommonButton>
+        <ButtonContainer>
+          <NewCommonButton size={'sm'} onClick={handleSubmit}>
+            편집 완료
+          </NewCommonButton>
+        </ButtonContainer>
       </ContentContainer>
     </AppContainer>
   );

--- a/src/pages/admin/AdminWorkspaceEdit.tsx
+++ b/src/pages/admin/AdminWorkspaceEdit.tsx
@@ -27,7 +27,7 @@ const inputStyle = `
 `;
 
 const containerStyle = css`
-  width: 100%;
+  width: 95%;
   gap: 10px;
   ${colFlex({ justify: 'center', align: 'start' })}
 `;

--- a/src/pages/admin/order/AdminOrderRealtime.tsx
+++ b/src/pages/admin/order/AdminOrderRealtime.tsx
@@ -15,7 +15,7 @@ import styled from '@emotion/styled';
 import { useWakeLock } from '@hooks/useWakeLock';
 
 const ListContainer = styled.div`
-  width: 100%;
+  width: 95%;
   gap: 20px;
   ${colFlex({ justify: 'center', align: 'center' })}
 `;
@@ -40,7 +40,7 @@ function AdminOrderRealtime() {
   }, []);
 
   return (
-    <AppContainer useFlex={colFlex({ justify: 'center' })}>
+    <AppContainer useFlex={colFlex({ justify: 'start', align: 'center' })}>
       <ListContainer>
         <TitledOrderStatusList
           orders={notPaidOrders}

--- a/src/pages/admin/order/AdminOrderStatistics.tsx
+++ b/src/pages/admin/order/AdminOrderStatistics.tsx
@@ -14,7 +14,7 @@ import { formatMinutesToTime } from '@utils/formatDate';
 import { Color } from '@resources/colors';
 
 const Container = styled.div`
-  width: 100%;
+  width: 95%;
   flex: 1;
   gap: 20px;
   padding-top: 25px;
@@ -85,7 +85,7 @@ function AdminOrderStatistics() {
   const comparisonColor = comparison ? getComparisonColor(comparison.revenueGrowthRate) : undefined;
 
   return (
-    <AppContainer useFlex={colFlex({ justify: 'start' })} customWidth={'1200px'}>
+    <AppContainer useFlex={colFlex({ justify: 'start', align: 'center' })} customWidth={'1200px'}>
       <Container>
         <FilterContainer>
           <CustomSelect value={dateLabel} triggerLabel={dateLabel} highlightOnSelect={true} width="160px">

--- a/src/pages/admin/order/AdminOrderTimeline.tsx
+++ b/src/pages/admin/order/AdminOrderTimeline.tsx
@@ -19,6 +19,10 @@ import { TIMELINE_COLORS } from '@components/admin/order/timeline/timelineConsta
 import { RiRefreshLine } from '@remixicon/react';
 import { expandButtonStyle } from '@styles/buttonStyles';
 
+const Container = styled.div`
+  width: 95%;
+`;
+
 const FilterContainer = styled.div`
   width: 100%;
   margin-bottom: 20px;
@@ -88,8 +92,8 @@ function AdminOrderTimeline() {
   const dateLabel = format(selectedDate, 'yyyy년 MM월 dd일');
 
   return (
-    <AppContainer useFlex={colFlex({ justify: 'start' })} customWidth={'1200px'}>
-      <>
+    <AppContainer useFlex={colFlex({ justify: 'start', align: 'center' })} customWidth={'1200px'}>
+      <Container>
         <FilterContainer>
           <FilterLeft>
             <CustomSelect value={dateLabel} triggerLabel={dateLabel} highlightOnSelect={true} width="160px">
@@ -131,7 +135,7 @@ function AdminOrderTimeline() {
         />
 
         {selectedSession && <SessionDetailModal session={selectedSession} currentTime={currentTime} isModalOpen={isModalOpen} closeModal={handleCloseModal} />}
-      </>
+      </Container>
     </AppContainer>
   );
 }

--- a/src/pages/admin/order/AdminTotalOrder.tsx
+++ b/src/pages/admin/order/AdminTotalOrder.tsx
@@ -14,6 +14,10 @@ import { OrderStatus } from '@@types/index';
 import { useAdminFetchTotalOrder } from '@hooks/admin/useAdminFetchTotalOrder';
 import StatCard from '@components/common/card/StatCard';
 
+const Container = styled.div`
+  width: 95%;
+`;
+
 const FilterContainer = styled.div`
   width: 100%;
   gap: 10px;
@@ -89,8 +93,8 @@ function AdminTotalOrder() {
   const dateRangeLabel = startDate && endDate ? `${startDate.toLocaleDateString()} ~ ${endDate.toLocaleDateString()}` : '날짜 선택';
 
   return (
-    <AppContainer useFlex={colFlex({ justify: 'start' })} customWidth={'1000px'}>
-      <>
+    <AppContainer useFlex={colFlex({ justify: 'start', align: 'center' })} customWidth={'1000px'}>
+      <Container>
         <FilterContainer>
           <ResetButton onClick={handleReset}>
             <RiRefreshLine size={14} />
@@ -125,7 +129,7 @@ function AdminTotalOrder() {
         ) : (
           <FallbackContainer>조회된 주문 내역이 없습니다.</FallbackContainer>
         )}
-      </>
+      </Container>
     </AppContainer>
   );
 }

--- a/src/pages/admin/table/AdminTableRealtime.tsx
+++ b/src/pages/admin/table/AdminTableRealtime.tsx
@@ -22,7 +22,7 @@ import NewCommonButton from '@components/common/button/NewCommonButton';
 import { RiSettings3Fill } from '@remixicon/react';
 
 const Container = styled.div`
-  width: 100%;
+  width: 95%;
   height: 100%;
   display: grid;
   grid-template-columns: 1fr 2fr;
@@ -49,13 +49,13 @@ const DetailHeader = styled.div`
 `;
 
 const RightColumn = styled.div`
-  ${colFlex()};
   gap: 12px;
+  ${colFlex()};
 `;
 
 const TopCards = styled.div`
-  ${rowFlex({ justify: 'space-between' })};
   gap: 5px;
+  ${rowFlex({ justify: 'space-between' })};
 `;
 
 const SettingIcon = styled(RiSettings3Fill)`
@@ -112,7 +112,7 @@ function AdminTableRealtime() {
   };
 
   return (
-    <AppContainer useFlex={colFlex({ justify: 'center', align: 'center' })}>
+    <AppContainer useFlex={colFlex({ justify: 'start', align: 'center' })}>
       <>
         <SettingsButtonContainer>
           <NewCommonButton size="sm" icon={<SettingIcon />} onClick={handleOpenSettings}>


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

**BEFORE**

https://github.com/user-attachments/assets/69d6ce8e-0c09-471d-af4d-d2c48d952e8a


**AFTER**

https://github.com/user-attachments/assets/b99de75a-36a7-4645-8e4b-5feeb71037e7


Admin 화면들의 콘텐츠 폭과 정렬 방식을 정리했습니다.

- 주문 관련 페이지의 콘텐츠 폭을 `width: 95%` 기준으로 통일
- Workspace Edit 화면의 입력 필드를 `NewAppInput`, `NewAppTextarea` 공통 컴포넌트로 교체
- Workspace Edi 화면에서 마지막 입력 필드와 `편집 완료` 버튼 사이 간격 추가

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)