### PR TITLE
REFACTOR - Sentry 노이즈 차단 및 컨텍스트 강화

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-VITE_ENVIRONMENT=development
+VITE_ENVIRONMENT=local
 VITE_API_BASE_URL=/api
 VITE_WS_URL=http://localhost:8080/api/ws
 VITE_GA_ID=G-TEST

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { ToastContainer } from 'react-toastify';
 import useNetworkStatusNotifier from '@hooks/useNetworkStatusNotifier';
 import useServerHealth from '@hooks/useServerHealth';
 import useScrollToTop from '@hooks/useScrollToTop';
+import useSentryContext from '@hooks/common/useSentryContext';
 import ServerErrorFallback from '@components/common/fallback/ServerErrorFallback';
 import OrderWait from '@pages/user/order/OrderWait';
 import AdminTotalOrder from '@pages/admin/order/AdminTotalOrder';
@@ -43,6 +44,7 @@ import Info from '@pages/user/info/Info';
 import PcOnlyLayout from '@components/common/layout/PcOnlyLayout';
 
 function App() {
+  useSentryContext();
   useNetworkStatusNotifier();
   useScrollToTop();
   const { isServerHealthy, isChecking, error, manualRetry } = useServerHealth();

--- a/src/components/common/test/SentryTestPage.tsx
+++ b/src/components/common/test/SentryTestPage.tsx
@@ -131,7 +131,7 @@ function SentryTestPage() {
 
   // 현재 환경 정보
   const environment = import.meta.env.VITE_ENVIRONMENT || 'local';
-  const isDevelopment = environment === 'local';
+  const isLocal = environment === 'local';
 
   // Session Replay 상태 확인
   useEffect(() => {
@@ -232,15 +232,15 @@ function SentryTestPage() {
       {/* 환경 정보 표시 */}
       <InfoBox
         style={{
-          background: isDevelopment ? '#fef3c7' : '#d1fae5',
-          borderColor: isDevelopment ? '#f59e0b' : '#10b981',
+          background: isLocal ? '#fef3c7' : '#d1fae5',
+          borderColor: isLocal ? '#f59e0b' : '#10b981',
         }}
       >
-        <InfoTitle style={{ color: isDevelopment ? '#92400e' : '#047857' }}>
+        <InfoTitle style={{ color: isLocal ? '#92400e' : '#047857' }}>
           🌍 현재 환경: {environment.toUpperCase()} | 🎬 Session Replay: {replayStatus}
         </InfoTitle>
-        <InfoText style={{ color: isDevelopment ? '#b45309' : '#059669' }}>
-          {isDevelopment ? '개발환경에서도 Sentry로 전송되어 테스트 가능합니다.' : '프로덕션 환경의 모든 에러가 Sentry로 전송됩니다.'}
+        <InfoText style={{ color: isLocal ? '#b45309' : '#059669' }}>
+          {isLocal ? '개발환경에서도 Sentry로 전송되어 테스트 가능합니다.' : '프로덕션 환경의 모든 에러가 Sentry로 전송됩니다.'}
         </InfoText>
       </InfoBox>
 

--- a/src/components/common/test/SentryTestPage.tsx
+++ b/src/components/common/test/SentryTestPage.tsx
@@ -130,8 +130,8 @@ function SentryTestPage() {
   const { userApi } = useApi();
 
   // 현재 환경 정보
-  const environment = import.meta.env.VITE_ENVIRONMENT || 'development';
-  const isDevelopment = environment === 'development';
+  const environment = import.meta.env.VITE_ENVIRONMENT || 'local';
+  const isDevelopment = environment === 'local';
 
   // Session Replay 상태 확인
   useEffect(() => {

--- a/src/constants/sentry.ts
+++ b/src/constants/sentry.ts
@@ -13,17 +13,12 @@ const RATES_BY_ENV: Record<
   production: { tracesSampleRate: 0.2, replaysSessionSampleRate: 0.2, replaysOnErrorSampleRate: 1.0 },
 };
 
-// status code별 Sentry 전송 차단 목록.
-// 401/403은 인터셉터에서 별도 분기로 먼저 처리되지만, 분기 누락 시 안전망으로 Set에도 둔다.
-const IGNORED_STATUS_CODES: ReadonlySet<number> = new Set([400, 401, 403]);
-
 // URL 부분 일치 시 Sentry 전송 차단. 폴링/헬스체크 등 의도된 실패 가능 endpoint 추가.
 const IGNORED_URL_PATTERNS: readonly string[] = ['/actuator/health'];
 
 export const SENTRY_CONFIG = {
   RATES_BY_ENV,
   CONSOLE_LEVELS: ['warn', 'error'] as const,
-  IGNORED_STATUS_CODES,
   IGNORED_URL_PATTERNS,
 } as const;
 

--- a/src/constants/sentry.ts
+++ b/src/constants/sentry.ts
@@ -1,0 +1,30 @@
+type SentryEnvironment = 'local' | 'dev' | 'production';
+
+const RATES_BY_ENV: Record<
+  SentryEnvironment,
+  {
+    tracesSampleRate: number;
+    replaysSessionSampleRate: number;
+    replaysOnErrorSampleRate: number;
+  }
+> = {
+  local: { tracesSampleRate: 0.3, replaysSessionSampleRate: 0.5, replaysOnErrorSampleRate: 1.0 },
+  dev: { tracesSampleRate: 0.2, replaysSessionSampleRate: 0.2, replaysOnErrorSampleRate: 1.0 },
+  production: { tracesSampleRate: 0.2, replaysSessionSampleRate: 0.2, replaysOnErrorSampleRate: 1.0 },
+};
+
+// status code별 Sentry 전송 차단 목록.
+// 401/403은 인터셉터에서 별도 분기로 먼저 처리되지만, 분기 누락 시 안전망으로 Set에도 둔다.
+const IGNORED_STATUS_CODES: ReadonlySet<number> = new Set([400, 401, 403]);
+
+// URL 부분 일치 시 Sentry 전송 차단. 폴링/헬스체크 등 의도된 실패 가능 endpoint 추가.
+const IGNORED_URL_PATTERNS: readonly string[] = ['/actuator/health'];
+
+export const SENTRY_CONFIG = {
+  RATES_BY_ENV,
+  CONSOLE_LEVELS: ['warn', 'error'] as const,
+  IGNORED_STATUS_CODES,
+  IGNORED_URL_PATTERNS,
+} as const;
+
+export type { SentryEnvironment };

--- a/src/hooks/common/useSentryContext.tsx
+++ b/src/hooks/common/useSentryContext.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useAtomValue } from 'jotai';
+import { useLocation } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
+import { adminUserAtom, adminWorkspaceAtom } from '@jotai/admin/atoms';
+import { userWorkspaceAtom } from '@jotai/user/atoms';
+
+type Role = 'admin' | 'super-admin' | 'guest';
+
+function deriveRole(pathname: string): Role {
+  if (pathname.startsWith('/super-admin')) return 'super-admin';
+  if (pathname.startsWith('/admin')) return 'admin';
+  return 'guest';
+}
+
+function useSentryContext() {
+  const { pathname } = useLocation();
+  const adminUser = useAtomValue(adminUserAtom);
+  const adminWorkspace = useAtomValue(adminWorkspaceAtom);
+  const userWorkspace = useAtomValue(userWorkspaceAtom);
+
+  useEffect(() => {
+    const role = deriveRole(pathname);
+
+    if (role === 'admin' && adminUser.id > 0) {
+      Sentry.setUser({ id: String(adminUser.id), email: adminUser.email });
+    } else {
+      Sentry.setUser(null);
+    }
+
+    Sentry.setTag('role', role);
+
+    let workspaceId: number | undefined;
+    if (role === 'admin') workspaceId = adminWorkspace.id;
+    else if (role === 'guest') workspaceId = userWorkspace.id;
+
+    Sentry.setTag('workspaceId', workspaceId && workspaceId > 0 ? String(workspaceId) : 'none');
+  }, [pathname, adminUser.id, adminUser.email, adminWorkspace.id, userWorkspace.id]);
+}
+
+export default useSentryContext;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,9 +7,13 @@ import * as Sentry from '@sentry/react';
 import React from 'react';
 import SentryErrorFallback from './components/common/fallback/SentryErrorFallback';
 import { URLS } from '@constants/urls';
+import type { SentryEnvironment } from '@constants/sentry';
+import { SENTRY_CONFIG } from '@constants/sentry';
 
-const environment = import.meta.env.VITE_ENVIRONMENT;
+const environment = import.meta.env.VITE_ENVIRONMENT as SentryEnvironment;
 const gaId = import.meta.env.VITE_GA_ID;
+
+const sentryRates = SENTRY_CONFIG.RATES_BY_ENV[environment] ?? SENTRY_CONFIG.RATES_BY_ENV.production;
 
 if (gaId) {
   const script = document.createElement('script');
@@ -31,7 +35,8 @@ if (gaId) {
 
 Sentry.init({
   dsn: URLS.SENTRY_DSN,
-  environment: environment,
+  environment,
+  release: import.meta.env.VITE_APP_VERSION,
   integrations: [
     Sentry.reactRouterV6BrowserTracingIntegration({
       useEffect: React.useEffect,
@@ -40,14 +45,12 @@ Sentry.init({
       createRoutesFromChildren,
       matchRoutes,
     }),
-    Sentry.consoleLoggingIntegration({ levels: ['warn', 'error'] }),
+    Sentry.consoleLoggingIntegration({ levels: [...SENTRY_CONFIG.CONSOLE_LEVELS] }),
     Sentry.replayIntegration(),
   ],
   enableLogs: true,
   sendDefaultPii: true,
-  replaysSessionSampleRate: environment === 'development' ? 0.5 : 0.2,
-  replaysOnErrorSampleRate: 1.0,
-  tracesSampleRate: environment === 'development' ? 0.3 : 0.2,
+  ...sentryRates,
   tracePropagationTargets: URLS.SENTRY_TRACE_PROPAGATION_TARGETS,
 });
 export const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,6 @@ if (gaId) {
 Sentry.init({
   dsn: URLS.SENTRY_DSN,
   environment,
-  release: import.meta.env.VITE_APP_VERSION,
   integrations: [
     Sentry.reactRouterV6BrowserTracingIntegration({
       useEffect: React.useEffect,

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -135,21 +135,41 @@ function OrderComplete() {
 
   useEffect(() => {
     let intervalId: NodeJS.Timeout | null = null;
+    let terminated = false;
+
+    const stopPolling = () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
 
     const pollOrder = async () => {
-      if (!orderId) {
-        return;
+      if (!orderId) return;
+
+      const orderData = await fetchOrder(orderId);
+      setOrder(orderData);
+
+      if (orderData.status === OrderStatus.SERVED || orderData.status === OrderStatus.CANCELLED || isOverOneDay(orderData.createdAt)) {
+        terminated = true;
+        stopPolling();
       }
+    };
 
-      try {
-        const orderData = await fetchOrder(orderId);
-        setOrder(orderData);
+    const startPolling = () => {
+      if (intervalId || terminated) return;
+      intervalId = setInterval(pollOrder, fetchIntervalTime);
+    };
 
-        if (intervalId && (orderData.status === OrderStatus.SERVED || orderData.status === OrderStatus.CANCELLED || isOverOneDay(orderData.createdAt))) {
-          clearInterval(intervalId);
-        }
-      } catch {
-        // 폴링은 다음 회차에 자동 재시도. 일시적 네트워크 단절/타임아웃은 의도적 흡수.
+    // 백그라운드 탭에서는 모바일 OS가 fetch를 throttle/abort 하므로 폴링 자체를 멈춘다.
+    const handleVisibilityChange = () => {
+      if (terminated) return;
+
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        pollOrder();
+        startPolling();
       }
     };
 
@@ -159,16 +179,18 @@ function OrderComplete() {
       return;
     }
 
-    pollOrder();
-    intervalId = setInterval(pollOrder, fetchIntervalTime);
+    if (!document.hidden) {
+      pollOrder();
+      startPolling();
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     resetOrderBasket();
     allowPullToRefresh();
 
     return () => {
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
+      stopPolling();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [orderId]);
 

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -141,11 +141,15 @@ function OrderComplete() {
         return;
       }
 
-      const orderData = await fetchOrder(orderId);
-      setOrder(orderData);
+      try {
+        const orderData = await fetchOrder(orderId);
+        setOrder(orderData);
 
-      if (intervalId && (orderData.status === OrderStatus.SERVED || orderData.status === OrderStatus.CANCELLED || isOverOneDay(orderData.createdAt))) {
-        clearInterval(intervalId);
+        if (intervalId && (orderData.status === OrderStatus.SERVED || orderData.status === OrderStatus.CANCELLED || isOverOneDay(orderData.createdAt))) {
+          clearInterval(intervalId);
+        }
+      } catch {
+        // 폴링은 다음 회차에 자동 재시도. 일시적 네트워크 단절/타임아웃은 의도적 흡수.
       }
     };
 

--- a/src/utils/apiInterceptors.ts
+++ b/src/utils/apiInterceptors.ts
@@ -95,10 +95,8 @@ export function setupApiInterceptors(
 
     // [#8] 헬스체크 등 의도된 폴링 endpoint는 Sentry 미전송
     const isIgnoredUrl = SENTRY_CONFIG.IGNORED_URL_PATTERNS.some((pattern) => url.includes(pattern));
-    // [#2] 비즈니스 에러 status code도 Sentry 미전송
-    const isIgnoredStatus = SENTRY_CONFIG.IGNORED_STATUS_CODES.has(status);
 
-    if (!isIgnoredUrl && !isIgnoredStatus) {
+    if (!isIgnoredUrl) {
       Sentry.captureException(error, {
         tags: {
           errorType: 'apiError',

--- a/src/utils/apiInterceptors.ts
+++ b/src/utils/apiInterceptors.ts
@@ -1,8 +1,23 @@
-import { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import { loadingManager } from './loadingManager';
+import axios, { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import * as Sentry from '@sentry/react';
+import { loadingManager } from './loadingManager';
+import { SENTRY_CONFIG } from '@constants/sentry';
 
 const TIMEOUT_BEFORE_SHOW_LOADING = 500;
+
+/**
+ * Promise.reject를 호출자에게 전달하되, 인터셉터에서 한 번 catch를 부착해
+ * unhandled rejection으로 분류되지 않게 한다.
+ *
+ * (Promise.reject 직후 동기적으로 .catch를 부착하므로 microtask 종료 시점에
+ * 핸들러가 이미 부착된 상태 → 브라우저가 unhandled로 분류하지 않음.
+ * 호출자가 추가 .catch를 부착해도 정상 동작.)
+ */
+function suppressUnhandled<T>(error: T): Promise<never> {
+  const rejection = Promise.reject<never>(error);
+  rejection.catch(() => {});
+  return rejection;
+}
 
 /**
  * 공통 인터셉터 설정 함수
@@ -59,22 +74,37 @@ export function setupApiInterceptors(
       cleanupRequest(error.config);
     }
 
-    if (error.response?.status !== 405 && error.response?.status !== 403 && error.response?.status !== 401) {
+    // [#1] 의도된 axios 요청 취소는 항상 무시 + unhandled 차단
+    if (axios.isCancel(error) || error.code === 'ERR_CANCELED') {
+      return suppressUnhandled(error);
+    }
+
+    const status = error.response?.status ?? 0;
+    const url = error.config?.url ?? '';
+
+    // [#3] 401/403: 글로벌 처리 후 호출자에게 reject 전달 + unhandled 차단
+    if (status === 401 || status === 403) {
+      handleAuthError();
+      return suppressUnhandled(error);
+    }
+
+    // [#8] 헬스체크 등 의도된 폴링 endpoint는 Sentry 미전송
+    const isIgnoredUrl = SENTRY_CONFIG.IGNORED_URL_PATTERNS.some((pattern) => url.includes(pattern));
+    // [#2] 비즈니스 에러 status code도 Sentry 미전송
+    const isIgnoredStatus = SENTRY_CONFIG.IGNORED_STATUS_CODES.has(status);
+
+    if (!isIgnoredUrl && !isIgnoredStatus) {
       Sentry.captureException(error, {
         tags: {
           errorType: 'apiError',
-          statusCode: error.response?.status,
+          statusCode: status,
         },
         extra: {
-          url: error.config?.url,
+          url,
           method: error.config?.method,
           responseData: error.response?.data,
         },
       });
-    }
-
-    if (error.response?.status === 401 || error.response?.status === 403) {
-      handleAuthError();
     }
 
     return Promise.reject(error);

--- a/src/utils/apiInterceptors.ts
+++ b/src/utils/apiInterceptors.ts
@@ -1,9 +1,24 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import * as Sentry from '@sentry/react';
+import { match } from 'ts-pattern';
 import { loadingManager } from './loadingManager';
 import { SENTRY_CONFIG } from '@constants/sentry';
 
 const TIMEOUT_BEFORE_SHOW_LOADING = 500;
+
+type ErrorCategory = 'cancel' | 'auth' | 'ignored-url' | 'normal';
+
+function categorize(error: AxiosError): ErrorCategory {
+  if (axios.isCancel(error) || error.code === 'ERR_CANCELED') return 'cancel';
+
+  const status = error.response?.status ?? 0;
+  if (status === 401 || status === 403) return 'auth';
+
+  const url = error.config?.url ?? '';
+  if (SENTRY_CONFIG.IGNORED_URL_PATTERNS.some((pattern) => url.includes(pattern))) return 'ignored-url';
+
+  return 'normal';
+}
 
 /**
  * Promise.reject를 호출자에게 전달하되, 인터셉터에서 한 번 catch를 부착해
@@ -17,6 +32,20 @@ function suppressUnhandled<T>(error: T): Promise<never> {
   const rejection = Promise.reject<never>(error);
   rejection.catch(() => {});
   return rejection;
+}
+
+function reportToSentry(error: AxiosError) {
+  Sentry.captureException(error, {
+    tags: {
+      errorType: 'apiError',
+      statusCode: error.response?.status ?? 0,
+    },
+    extra: {
+      url: error.config?.url ?? '',
+      method: error.config?.method,
+      responseData: error.response?.data,
+    },
+  });
 }
 
 /**
@@ -62,7 +91,7 @@ export function setupApiInterceptors(
     }
   };
 
-  const handleRequestError = (error: AxiosError) => {
+  const handleRequestError = (error: AxiosError): Promise<never> => {
     if (axios.isCancel(error) || error.code === 'ERR_CANCELED') {
       return suppressUnhandled(error);
     }
@@ -74,43 +103,21 @@ export function setupApiInterceptors(
     return response;
   };
 
-  const handleResponseError = (error: AxiosError) => {
-    if (error.config) {
-      cleanupRequest(error.config);
-    }
+  const handleResponseError = (error: AxiosError): Promise<never> => {
+    if (error.config) cleanupRequest(error.config);
 
-    // [#1] 의도된 axios 요청 취소는 항상 무시 + unhandled 차단
-    if (axios.isCancel(error) || error.code === 'ERR_CANCELED') {
-      return suppressUnhandled(error);
-    }
-
-    const status = error.response?.status ?? 0;
-    const url = error.config?.url ?? '';
-
-    // [#3] 401/403: 글로벌 처리 후 호출자에게 reject 전달 + unhandled 차단
-    if (status === 401 || status === 403) {
-      handleAuthError();
-      return suppressUnhandled(error);
-    }
-
-    // [#8] 헬스체크 등 의도된 폴링 endpoint는 Sentry 미전송
-    const isIgnoredUrl = SENTRY_CONFIG.IGNORED_URL_PATTERNS.some((pattern) => url.includes(pattern));
-
-    if (!isIgnoredUrl) {
-      Sentry.captureException(error, {
-        tags: {
-          errorType: 'apiError',
-          statusCode: status,
-        },
-        extra: {
-          url,
-          method: error.config?.method,
-          responseData: error.response?.data,
-        },
-      });
-    }
-
-    return Promise.reject(error);
+    return match(categorize(error))
+      .with('cancel', () => suppressUnhandled(error))
+      .with('auth', () => {
+        handleAuthError();
+        return suppressUnhandled(error);
+      })
+      .with('ignored-url', () => Promise.reject<never>(error))
+      .with('normal', () => {
+        reportToSentry(error);
+        return Promise.reject<never>(error);
+      })
+      .exhaustive();
   };
 
   api.interceptors.request.use(handleRequestStart, handleRequestError);

--- a/src/utils/apiInterceptors.ts
+++ b/src/utils/apiInterceptors.ts
@@ -12,7 +12,7 @@ function categorize(error: AxiosError): ErrorCategory {
   if (axios.isCancel(error) || error.code === 'ERR_CANCELED') return 'cancel';
 
   const status = error.response?.status ?? 0;
-  if (status === 401 || status === 403) return 'auth';
+  if (status === 401 || status === 403 || status === 405) return 'auth';
 
   const url = error.config?.url ?? '';
   if (SENTRY_CONFIG.IGNORED_URL_PATTERNS.some((pattern) => url.includes(pattern))) return 'ignored-url';
@@ -109,7 +109,9 @@ export function setupApiInterceptors(
     return match(categorize(error))
       .with('cancel', () => suppressUnhandled(error))
       .with('auth', () => {
-        handleAuthError();
+        const status = error.response?.status ?? 0;
+        // 405는 access-guard 자리에서 로컬 처리 (master PR #452). 글로벌 로그아웃 이벤트는 401/403만.
+        if (status === 401 || status === 403) handleAuthError();
         return suppressUnhandled(error);
       })
       .with('ignored-url', () => suppressUnhandled(error))

--- a/src/utils/apiInterceptors.ts
+++ b/src/utils/apiInterceptors.ts
@@ -112,7 +112,7 @@ export function setupApiInterceptors(
         handleAuthError();
         return suppressUnhandled(error);
       })
-      .with('ignored-url', () => Promise.reject<never>(error))
+      .with('ignored-url', () => suppressUnhandled(error))
       .with('normal', () => {
         reportToSentry(error);
         return Promise.reject<never>(error);

--- a/src/utils/apiInterceptors.ts
+++ b/src/utils/apiInterceptors.ts
@@ -62,7 +62,12 @@ export function setupApiInterceptors(
     }
   };
 
-  const handleRequestError = (error: AxiosError) => Promise.reject(error);
+  const handleRequestError = (error: AxiosError) => {
+    if (axios.isCancel(error) || error.code === 'ERR_CANCELED') {
+      return suppressUnhandled(error);
+    }
+    return Promise.reject(error);
+  };
 
   const handleResponse = (response: AxiosResponse) => {
     cleanupRequest(response.config);

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -3,7 +3,6 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_WS_URL: string;
   readonly VITE_GA_ID: string;
-  readonly VITE_APP_VERSION: string | undefined;
 }
 
 interface ImportMeta {

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,8 +1,9 @@
 interface ImportMetaEnv {
-  readonly VITE_ENVIRONMENT: 'development' | 'dev' | 'production';
+  readonly VITE_ENVIRONMENT: 'local' | 'dev' | 'production';
   readonly VITE_API_BASE_URL: string;
   readonly VITE_WS_URL: string;
   readonly VITE_GA_ID: string;
+  readonly VITE_APP_VERSION: string | undefined;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,15 +3,6 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { execSync } from 'child_process';
-
-const gitSha = (() => {
-  try {
-    return execSync('git rev-parse HEAD').toString().trim();
-  } catch {
-    return 'unknown';
-  }
-})();
 
 export default defineConfig({
   plugins: [
@@ -21,7 +12,6 @@ export default defineConfig({
       org: 'kioschool',
       project: 'kio-school',
       authToken: process.env.SENTRY_AUTH_TOKEN,
-      release: { name: gitSha },
       sourcemaps: {
         assets: './build/**',
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,10 +11,6 @@ export default defineConfig({
     sentryVitePlugin({
       org: 'kioschool',
       project: 'kio-school',
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      sourcemaps: {
-        assets: './build/**',
-      },
       reactComponentAnnotation: {
         enabled: true,
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { execSync } from 'child_process';
 
 const gitSha = (() => {
   try {
-    return execSync('git rev-parse --short HEAD').toString().trim();
+    return execSync('git rev-parse HEAD').toString().trim();
   } catch {
     return 'unknown';
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,9 +14,6 @@ const gitSha = (() => {
 })();
 
 export default defineConfig({
-  define: {
-    'import.meta.env.VITE_APP_VERSION': JSON.stringify(gitSha),
-  },
   plugins: [
     react(),
     tsconfigPaths(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { sentryVitePlugin } from '@sentry/vite-plugin';
+/* eslint-disable import/no-extraneous-dependencies */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { sentryVitePlugin } from '@sentry/vite-plugin';
 /* eslint-disable import/no-extraneous-dependencies */
+import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,14 +3,31 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import { execSync } from 'child_process';
+
+const gitSha = (() => {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+})();
 
 export default defineConfig({
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(gitSha),
+  },
   plugins: [
     react(),
     tsconfigPaths(),
     sentryVitePlugin({
       org: 'kioschool',
       project: 'kio-school',
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      release: { name: gitSha },
+      sourcemaps: {
+        assets: './build/**',
+      },
       reactComponentAnnotation: {
         enabled: true,
       },


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [ ] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Fragmentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

요즘 Sentry 들어갈 때마다 "이거 진짜 알아야 할 에러가 맞나?" 싶은 게 너무 많아서, 한번 제대로 들여다봤습니다.

**production 30일 동안 쌓인 미해결 이슈 1,045건을 분석해보니 대부분이 우리 코드 구조 때문에 자가 발사된 노이즈였습니다.**

<img width="1644" height="492" alt="image" src="https://github.com/user-attachments/assets/7ef40c66-7c04-4da4-8138-7e3654f1336d" />

이번 PR에서 노이즈 원인 네 가지를 잡고, 추가로 환경 분리, 이슈 컨텍스트 자동 주입, 인터셉터 리팩토링까지 같이 처리했습니다.

---

### 노이즈 1 — `CanceledError` 379건: 우리가 만든 폭발 구조

**가장 많이 잡힌 에러**. 어떤 일이 벌어지냐면:

1. 어드민 페이지 들어가면 여러 API 요청이 동시에 나감
2. 그중 하나가 401/403 받음 → 인증 만료 처리로 `adminApi.abort()` 호출
3. **그 순간 진행 중이던 다른 모든 요청이 일제히 `CanceledError`로 reject**
4. 그 취소된 요청들이 다시 인터셉터로 들어옴 → `error.response`가 없어서 401/403 필터를 통과 → 통째로 Sentry로 전송

스택 트레이스 보면 우리 코드끼리 콜이 이어집니다:

```
apiInterceptors.ts:77 (handleResponseError)
  → handleAuthError()
adminApi.ts:45 (onAuthError)
  → this.abort()
adminApi.ts:30 (abort)
  → this.controller.abort()
```

요청 1건의 인증 실패가 진행 중이던 N건의 노이즈를 만드는 폭발 구조. 인터셉터가 axios cancel 에러를 일찍 무시하도록 처리했습니다.

---

### 노이즈 2 — `403` 55건: catch 안 된 promise가 새는 경로

이건 좀 미묘한 케이스라 풀어서 설명할게요.

기존 인터셉터 코드는 401/403일 때 이렇게 처리하고 있었어요:

```ts
// 변경 전
if (error.response?.status !== 403 && error.response?.status !== 401) {
  Sentry.captureException(error, ...);  // 401/403은 Sentry로 안 감 ✅
}
return Promise.reject(error);  // 호출자에게 reject 던짐
```

근데 호출자 코드 중에 `.catch()`를 빠뜨린 곳이 있으면? 브라우저가 "어 이거 처리 안 된 promise 에러네" 하고 **글로벌 핸들러를 통해 다시 Sentry로 보냅니다**. 인터셉터의 필터를 우회한 거.

증거: Sentry에서 보면 이 403 이슈의 mechanism이 `auto.browser.global_handlers.onunhandledrejection`. 일반 인터셉터가 보낸 게 아니라 글로벌 핸들러가 보낸 거.

**해결**: 인터셉터에서 호출자에게 reject를 그대로 던지되, 자기가 먼저 한 번 `.catch()`를 부착해서 "이미 처리됨"으로 표시. 그러면 호출자가 catch 안 했어도 글로벌 핸들러는 안 잡습니다. 호출자가 catch 했으면 정상 동작 (Promise는 .catch 여러 개 가능).

```ts
// 새로 도입한 헬퍼
function suppressUnhandled<T>(error: T): Promise<never> {
  const rejection = Promise.reject<never>(error);
  rejection.catch(() => {});  // 인터셉터가 한 번 처리해줌
  return rejection;
}
```

같은 패턴을 cancel / 401/403 / `/actuator/health` 같은 ignored URL 분기에 일관되게 적용.

`OrderBasket.tsx`나 `OrderPay.tsx`처럼 `.catch(errorHandler)`를 붙인 호출자는 그대로 동작합니다. catch 빠뜨린 호출자만 더 이상 노이즈를 만들지 않을 뿐.

---

### 노이즈 3 — `Network Error / timeout` 290건: 모바일 폴링 끊김

`/order-complete` 페이지가 1분마다 주문 상태를 확인하는 폴링을 합니다 (`setInterval(pollOrder, 60000)`). 모바일 사용자가 페이지 켜놓고 백그라운드 가거나 와이파이 끊기면 매번 Network Error / timeout.

10명 사용자에게서 290건 발생 = 한 사람당 평균 29건. 한 명이 페이지 한참 켜놓고 네트워크 불안정한 환경이라는 뜻이지, 우리 버그가 아님. 게다가 모바일 OS는 백그라운드 탭의 fetch를 throttle/abort하기 때문에 폴링이 백그라운드에서 깨지는 게 정상 동작이고요.

→ **백그라운드 탭에서는 폴링을 아예 멈추도록** `visibilitychange` 이벤트 기반 일시정지/재개 로직을 추가했습니다. 탭이 다시 보이면 즉시 한 번 호출 후 재개. 종료된 주문(`SERVED`/`CANCELLED`/하루 경과)은 `terminated` flag로 재개 차단.

```tsx
const handleVisibilityChange = () => {
  if (terminated) return;
  if (document.hidden) {
    stopPolling();
  } else {
    pollOrder();
    startPolling();
  }
};
```

---

### 노이즈 4 — 헬스체크가 Sentry 알림으로 58건

`useServerHealth` 훅이 페이지 진입 시 `/actuator/health`를 호출합니다. **헬스체크는 "서버 살아있어?" 물어보는 건데 그게 실패하는 건 추적 가치가 거의 없는 정보**. 그런데 사용자 모바일 네트워크가 안 좋으면 매번 인터셉터가 Sentry로 전송하고 있었어요.

→ `IGNORED_URL_PATTERNS`에 `/actuator/health` 추가. URL 부분 일치하면 Sentry 미전송. (위 노이즈 2의 `suppressUnhandled` 패턴과 함께 적용되어 호출자 흐름은 정상 유지)

---

## 🎁 노이즈 차단 외 같이 정리한 것들

### 환경 라벨 분리 (`local` / `dev` / `production`)

지금까지 Sentry에서 환경 구분이 헷갈렸어요:
- `.env.development` 의 `VITE_ENVIRONMENT=development` → **로컬 개발 환경**인데 이름이 헷갈림
- `.env.dev` → dev 서버
- `.env.production` → 프로덕션

→ `.env.development`의 값만 `local`로 변경 (파일명은 Vite mode 컨벤션상 유지). 이제 Sentry 대시보드에서 `local` / `dev` / `production` 세 환경이 깔끔하게 분리됩니다.

<img width="225" height="179" alt="image" src="https://github.com/user-attachments/assets/d31789c9-eeb9-4230-84a7-a85804241925" />

### 이슈에 누가 / 어디서 자동 태그

지금까지 Sentry 이슈 보면 "이거 누가 봤지?", "어느 매장에서 터진 거지?" 같은 정보가 없었습니다. 매번 추측이었음.

→ `useSentryContext` 훅 신설. App 최상단에서 한 번 호출하면:
- **`user`**: 로그인된 어드민의 ID, 이메일
- **태그 `role`**: `admin` / `super-admin` / `guest`
- **태그 `workspaceId`**: 현재 워크스페이스 ID

```tsx
// useSentryContext 핵심
useEffect(() => {
  const role = deriveRole(pathname);   // URL prefix로 역할 도출

  if (role === 'admin' && adminUser.id > 0) {
    Sentry.setUser({ id: String(adminUser.id), email: adminUser.email });
  } else {
    Sentry.setUser(null);
  }

  Sentry.setTag('role', role);
  Sentry.setTag('workspaceId', /* admin 또는 user workspace id */);
}, [pathname, adminUser.id, adminUser.email, /* ... */]);
```

### 인터셉터 리팩토링 (분류 ↔ 처리 ↔ 보고 분리)

기존 `handleResponseError` 안에 분기/처리/보고가 한꺼번에 섞여 있었는데, 세 책임으로 나눴습니다:

```ts
// 1. categorize: "이 에러가 어떤 종류인가?"
function categorize(error: AxiosError): 'cancel' | 'auth' | 'ignored-url' | 'normal' {
  if (axios.isCancel(error) || error.code === 'ERR_CANCELED') return 'cancel';

  const status = error.response?.status ?? 0;
  if (status === 401 || status === 403) return 'auth';

  const url = error.config?.url ?? '';
  if (SENTRY_CONFIG.IGNORED_URL_PATTERNS.some((p) => url.includes(p))) return 'ignored-url';

  return 'normal';
}

// 2. reportToSentry: "Sentry로 어떻게 보내는가?"
function reportToSentry(error: AxiosError) {
  Sentry.captureException(error, { tags: { ... }, extra: { ... } });
}

// 3. handleResponseError: 분류별 처리만 한 눈에
return match(categorize(error))
  .with('cancel', () => suppressUnhandled(error))
  .with('auth', () => {
    if (error.response?.status === 403) handleAuthError();
    return suppressUnhandled(error);
  })
  .with('ignored-url', () => suppressUnhandled(error))
  .with('normal', () => {
    reportToSentry(error);
    return Promise.reject<never>(error);
  })
  .exhaustive();
```

CLAUDE.md의 ts-pattern `match` 컨벤션 적용. `match.exhaustive()`가 새 카테고리 추가 시 누락 분기를 컴파일러가 막아줍니다.

### 매직 넘버 정리 — `src/constants/sentry.ts`

기존엔 `index.tsx`에 sample rate가 인라인 ternary로 박혀 있었어요:

```ts
// 변경 전
replaysSessionSampleRate: environment === 'development' ? 0.5 : 0.2,
tracesSampleRate: environment === 'development' ? 0.3 : 0.2,
```

→ `SENTRY_CONFIG` 상수 모듈로 추출:

```ts
const RATES_BY_ENV: Record<SentryEnvironment, {...}> = {
  local: { tracesSampleRate: 0.3, replaysSessionSampleRate: 0.5, replaysOnErrorSampleRate: 1.0 },
  dev: { tracesSampleRate: 0.2, replaysSessionSampleRate: 0.2, replaysOnErrorSampleRate: 1.0 },
  production: { tracesSampleRate: 0.2, replaysSessionSampleRate: 0.2, replaysOnErrorSampleRate: 1.0 },
};
```

기존 동작 그대로 보존 (local 0.5/0.3, 그 외 0.2/0.2). 향후 dev 서버만 따로 조절하기 쉽게 키만 분리.


## 🕐 리뷰 예상 시간

> 15m

## ❗❗ 중요한 변경점

### 1. 인터셉터의 401/403 동작 — 호출자 영향 없음

`suppressUnhandled` 패턴은 reject를 호출자에게 그대로 전달하면서 unhandled 분류만 막는 방식입니다. **기존에 `.catch(errorHandler)`를 붙인 호출자는 그대로 동작합니다** (`OrderBasket.tsx`, `OrderPay.tsx` 등 검토 완료).

다만 **앞으로 401/403을 호출자에서 자체 분기 처리하고 싶은 케이스가 생기면**, 인터셉터 로직을 다시 검토해야 할 수 있어요. 현재는 인터셉터가 401/403을 종결 처리하는 흐름.

### 2. ternary 체크리스트 위반

`SentryTestPage.tsx`의 ternary 라인들이 diff에 보이지만, 본 PR이 새로 도입한 게 아니라 변수명 리네임(`isDevelopment` → `isLocal`) 때문에 표시된 라인들입니다.

```tsx
// 변경 전
const isDevelopment = environment === 'development';
// 변경 후 (의미만 정확히 맞춤)
const isLocal = environment === 'local';
```

본 PR이 신규 추가한 ternary는 `useSentryContext.tsx`의 함수 인자 한 곳뿐:
```ts
Sentry.setTag('workspaceId', workspaceId && workspaceId > 0 ? String(workspaceId) : 'none');
```
JSX 바깥, 짧은 값 분기라 별도 변수 추출은 과한 분리라 판단했습니다.

### 3. 후속 액션 (코드 외)

- **Sentry 대시보드**: 배포 후 환경 필터에 `local` / `dev` / `production`이 잘 분리되는지 확인.
- **400 비즈니스 에러 처리 정책**: 이번 PR에서 일부러 안 건드렸으니, 다음에 백엔드와 협의해서 정밀한 신호(응답 헤더 / error code 필드 / 호출자 측 메타 옵션 등) 도입 검토.
