### PR TITLE
REFACTOR - 어드민 query string 상태 관리 패턴 도입

### DIFF
--- a/src/components/common/nav/SideNav.tsx
+++ b/src/components/common/nav/SideNav.tsx
@@ -103,15 +103,6 @@ function SideNav({ isOpen }: SideNavProps) {
     return currentPath === path;
   };
 
-  const buildNavPath = (path: string, defaultQuery?: Record<string, string>): string => {
-    const fullPath = `${URL_PREFIX}${path}`;
-    if (!defaultQuery) return fullPath;
-
-    const queryString = new URLSearchParams(defaultQuery).toString();
-
-    return `${fullPath}?${queryString}`;
-  };
-
   return (
     <SideNavContainer isOpen={isOpen}>
       {adminNavData.map((categoryData) => (
@@ -119,7 +110,7 @@ function SideNav({ isOpen }: SideNavProps) {
           <CategoryTitle>{categoryData.category}</CategoryTitle>
           {categoryData.items.map((item) => (
             <NavItem key={item.path} isActive={isActiveLink(item.path)}>
-              <SideNavLink to={buildNavPath(item.path, item.defaultQuery)}>{item.name}</SideNavLink>
+              <SideNavLink to={`${URL_PREFIX}${item.path}`}>{item.name}</SideNavLink>
             </NavItem>
           ))}
         </NavCategory>

--- a/src/constants/data/adminNavData.ts
+++ b/src/constants/data/adminNavData.ts
@@ -1,7 +1,6 @@
 export interface AdminNavItem {
   name: string;
   path: string;
-  defaultQuery?: Record<string, string>;
 }
 
 export interface AdminNavCategory {
@@ -29,7 +28,6 @@ export const adminNavData: AdminNavCategory[] = [
       {
         name: '실시간 테이블 관리',
         path: '/table/realtime',
-        defaultQuery: { tableNo: '1' },
       },
     ],
   },

--- a/src/hooks/admin/useAdminFetchDailyStatistics.tsx
+++ b/src/hooks/admin/useAdminFetchDailyStatistics.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import { format } from 'date-fns';
+import useQueryParam from '@hooks/common/useQueryParam';
+import { dateQueryParamConfig } from '@hooks/common/queryParamConfigs';
 import useApi from '@hooks/useApi';
 import { DailyStatistics } from '@@types/index';
 
 export const useAdminFetchDailyStatistics = (workspaceId: string | undefined) => {
   const { adminApi } = useApi();
 
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const { value: selectedDate, setValue: setSelectedDate } = useQueryParam(dateQueryParamConfig);
   const [statistics, setStatistics] = useState<DailyStatistics | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/src/hooks/admin/useAdminFetchTableSessionTimeline.tsx
+++ b/src/hooks/admin/useAdminFetchTableSessionTimeline.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { format, differenceInMinutes } from 'date-fns';
 import useAdminOrder from '@hooks/admin/useAdminOrder';
+import useQueryParam from '@hooks/common/useQueryParam';
+import { dateQueryParamConfig } from '@hooks/common/queryParamConfigs';
 import { OrderSessionWithOrder } from '@@types/index';
 import { MIN_VALID_SESSION_MINUTES } from '@components/admin/order/timeline/timelineConstants';
 import { adminWorkspaceAtom } from '@jotai/admin/atoms';
@@ -29,7 +31,7 @@ export const useAdminFetchTableSessionTimeline = (workspaceId: string | undefine
   const { fetchOrderSessions } = useAdminOrder(workspaceId);
   const workspace = useAtomValue(adminWorkspaceAtom);
 
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const { value: selectedDate, setValue: setSelectedDate } = useQueryParam(dateQueryParamConfig);
   const [sessions, setSessions] = useState<OrderSessionWithOrder[]>([]);
   const [currentTime, setCurrentTime] = useState<Date>(new Date());
   const [isLoading, setIsLoading] = useState(false);

--- a/src/hooks/common/queryParamConfigs.ts
+++ b/src/hooks/common/queryParamConfigs.ts
@@ -1,0 +1,21 @@
+import { format, isValid, parse } from 'date-fns';
+import { RawQueryParamConfig, TypedQueryParamConfig } from '@hooks/common/useQueryParam';
+
+const DATE_FORMAT = 'yyyy-MM-dd';
+
+export const dateQueryParamConfig: TypedQueryParamConfig<Date> = {
+  key: 'date',
+  parse: (raw) => {
+    if (!raw) return null;
+    
+    const parsed = parse(raw, DATE_FORMAT, new Date());
+    return isValid(parsed) ? parsed : null;
+  },
+  serialize: (date) => format(date, DATE_FORMAT),
+  getDefault: () => new Date(),
+};
+
+export const tableNoQueryParamConfig: RawQueryParamConfig = {
+  key: 'tableNo',
+  getDefault: () => '1',
+};

--- a/src/hooks/common/queryParamConfigs.ts
+++ b/src/hooks/common/queryParamConfigs.ts
@@ -7,7 +7,7 @@ export const dateQueryParamConfig: TypedQueryParamConfig<Date> = {
   key: 'date',
   parse: (raw) => {
     if (!raw) return null;
-    
+
     const parsed = parse(raw, DATE_FORMAT, new Date());
     return isValid(parsed) ? parsed : null;
   },

--- a/src/hooks/common/useQueryParam.tsx
+++ b/src/hooks/common/useQueryParam.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export interface RawQueryParamConfig {
+  key: string;
+  getDefault: () => string;
+}
+
+export interface TypedQueryParamConfig<T> {
+  key: string;
+  parse: (raw: string | null) => T | null;
+  serialize: (value: T) => string;
+  getDefault: () => T;
+}
+
+type AnyQueryParamConfig<T> = RawQueryParamConfig | TypedQueryParamConfig<T>;
+
+function hasCodec<T>(config: AnyQueryParamConfig<T>): config is TypedQueryParamConfig<T> {
+  return 'parse' in config && 'serialize' in config;
+}
+
+function normalize<T>(config: AnyQueryParamConfig<T>): TypedQueryParamConfig<T> {
+  if (hasCodec(config)) return config;
+  return {
+    key: config.key,
+    parse: (raw) => raw as T | null,
+    serialize: (value) => value as unknown as string,
+    getDefault: config.getDefault as () => T,
+  };
+}
+
+function useQueryParam<T = string>(config: AnyQueryParamConfig<T>): { value: T; setValue: (next: T) => void } {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [{ key, parse, serialize, getDefault }] = useState(() => normalize(config));
+
+  const raw = searchParams.get(key);
+  const parsed = useMemo(() => parse(raw), [raw, parse]);
+  const value = useMemo(() => parsed ?? getDefault(), [parsed, getDefault]);
+
+  useEffect(() => {
+    if (parsed !== null) return;
+
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set(key, serialize(getDefault()));
+        return next;
+      },
+      { replace: true },
+    );
+  }, [parsed, key, serialize, getDefault, setSearchParams]);
+
+  const setValue = useCallback(
+    (next: T) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          params.set(key, serialize(next));
+          return params;
+        },
+        { replace: false },
+      );
+    },
+    [key, serialize, setSearchParams],
+  );
+
+  return { value, setValue };
+}
+
+export default useQueryParam;

--- a/src/pages/admin/table/AdminTableRealtime.tsx
+++ b/src/pages/admin/table/AdminTableRealtime.tsx
@@ -10,11 +10,13 @@ import AppContainer from '@components/common/container/AppContainer';
 import RightSidebarModal from '@components/common/modal/RightSidebarModal';
 import styled from '@emotion/styled';
 import useAdminWorkspace from '@hooks/admin/useAdminWorkspace';
+import useQueryParam from '@hooks/common/useQueryParam';
+import { tableNoQueryParamConfig } from '@hooks/common/queryParamConfigs';
 import useTableOrders from '@hooks/admin/useTableOrders';
 import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { useEffect, useState } from 'react';
-import { useParams, useSearchParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { adminWorkspaceAtom, externalSidebarAtom } from '@jotai/admin/atoms';
 import { RIGHT_SIDEBAR_ACTION, Table } from '@@types/index';
@@ -80,8 +82,7 @@ const FallbackContainer = styled.div`
 
 function AdminTableRealtime() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
-  const [searchParams] = useSearchParams();
-  const tableNo = searchParams.get('tableNo');
+  const { value: tableNo } = useQueryParam(tableNoQueryParamConfig);
   const { fetchWorkspaceTables } = useAdminWorkspace();
   const workspace = useAtomValue(adminWorkspaceAtom);
 


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Fragmentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

어드민 페이지 3곳(주문 타임라인, 주문 통계, 실시간 테이블 관리)의 화면 상태(`selectedDate`, `tableNo`)를 컴포넌트 `useState` → URL 쿼리스트링(`?date=`, `?tableNo=`)으로 이전했습니다. 새로고침·공유·뒤로가기 시 같은 뷰가 그대로 복원됩니다.

상태 보관 위치만 바꾸는 게 아니라, **"URL이 곧 진실"**이라는 패턴을 일급 시민으로 만드는 게 목적입니다. 어떤 진입 경로(nav 클릭, 주소창 입력, 외부 링크)로 들어와도 동일하게 동작하도록 default 주입 책임을 hook으로 끌어왔습니다. 그 결과 sidebar의 `defaultQuery` 메커니즘은 책임이 중복되어 제거했습니다.

https://github.com/user-attachments/assets/c14f7a5e-f7d4-4147-bac9-087232b9749c


### 주요 변경

- 신규 공통 hook: `src/hooks/common/useQueryParam.tsx`
  - `RawQueryParamConfig` (codec 불필요한 단순 string param)과 `TypedQueryParamConfig<T>` (codec 필요한 임의 타입) 두 종류 config를 받음
  - URL에 값이 없거나 무효하면 mount 시 `getDefault()`로 자동 보정 (`replace: true`)
  - setter는 `push`로 동작해 뒤로가기 지원, 다른 query 파라미터 보존
- 신규 config 모듈: `src/hooks/common/queryParamConfigs.ts`
  - `dateQueryParamConfig` (Date, `yyyy-MM-dd`)
  - `tableNoQueryParamConfig` (string, default `'1'`)
- 마이그레이션 적용처:
  - `useAdminFetchTableSessionTimeline` — `selectedDate` URL 이전
  - `useAdminFetchDailyStatistics` — `selectedDate` URL 이전
  - `AdminTableRealtime` — `tableNo` URL 이전 (기존 페이지에는 default fallback이 없어 nav가 책임지던 부분)
- nav 정리:
  - `adminNavData.ts`에서 `defaultQuery` 필드 제거
  - `SideNav.tsx`의 `buildNavPath` 제거, 인라인으로 단순화

### 동작 시나리오

| 진입/조작 | URL | 화면 |
|---|---|---|
| 첫 진입 (`/order-timeline`) | `?date=2026-04-26`로 자동 보정 | 오늘 데이터 |
| 4/14 선택 후 새로고침 | `?date=2026-04-14` 유지 | 4/14 데이터 |
| `?date=foo` 직접 입력 | 오늘로 자동 보정 (`replace`) | 오늘 데이터 |
| 4/14 → 4/13 후 뒤로가기 | `?date=2026-04-14`로 복귀 | 4/14 데이터 |
| 실시간 테이블 첫 진입 | `?tableNo=1` 자동 보정 | 1번 테이블 |



## 🕐 리뷰 예상 시간

> 10m

## ❗❗ 중요한 변경점(Option)

- **`useQueryParam`은 새 추상이라 디자인 결정 검토 필요**:
  - `RawQueryParamConfig` vs `TypedQueryParamConfig<T>` 두 종류로 분리한 이유 — codec 필요 여부는 T의 종류(string/non-string)가 아니라 config 쓰임새로 결정되어야 함 (예: `'asc' | 'desc'` 같은 string subtype도 검증 codec이 필요할 수 있음). 호출자가 명시적으로 선택하는 디자인.
  - mount 시 `normalize()`로 RawConfig를 TypedConfig로 정규화한 결과를 `useState` lazy init에 가둠. hook 본문에서 분기·cast가 모두 사라짐.
  - 단일 generic 시그니처 + `T = string` default로 RawConfig 호출 시 자동으로 string 반환 추론.
- **nav `defaultQuery` 메커니즘 제거**: 기존에 `defaultQuery: { tableNo: '1' }`로 nav가 default를 책임지던 구조였으나, "URL 명시성은 페이지/hook의 책임"이라는 일관된 원칙 적용. 이제 `AdminTableRealtime`이 mount 시 직접 default를 URL에 박음. 다른 nav item에는 기존에도 `defaultQuery`가 없어서 영향 없음.
