### PR TITLE
FIX - 이메일 도메인 추가 요청 오류 수정

### DIFF
--- a/src/components/common/popup/popup-content/PopupContent1.tsx
+++ b/src/components/common/popup/popup-content/PopupContent1.tsx
@@ -37,7 +37,7 @@ const Description = styled.div`
 `;
 
 function PopupContent1() {
-  const { sendPopupResult, closePopupForever } = usePopup();
+  const { sendAdminPopupResult, closePopupForever } = usePopup();
 
   const title = '키오스쿨 사용 인터뷰에 참여해주세요!';
   const description =
@@ -61,7 +61,7 @@ function PopupContent1() {
     - 입력한 전화번호: ${inputValue}
     `;
 
-    sendPopupResult(result);
+    sendAdminPopupResult(result);
 
     closePopupForever(1);
   };

--- a/src/components/user/email/RequestDomainPopup.tsx
+++ b/src/components/user/email/RequestDomainPopup.tsx
@@ -6,6 +6,7 @@ import NewCommonButton from '@components/common/button/NewCommonButton';
 import usePopup from '@hooks/usePopup';
 import { RiCloseCircleFill } from '@remixicon/react';
 import { Color } from '@resources/colors';
+import { getRequestDomainPopupResult, validateRequestDomainPopupForm } from '@utils/requestDomainPopup';
 
 const Container = styled.div`
   width: 100%;
@@ -75,24 +76,22 @@ function RequestDomainPopup({ onClose }: RequestDomainPopupProps) {
   const domainRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = () => {
-    const schoolName = schoolNameRef.current?.value;
-    const domain = domainRef.current?.value;
+    const { schoolName, emailOrDomain, errorMessage } = validateRequestDomainPopupForm(schoolNameRef.current?.value, domainRef.current?.value);
 
-    if (!schoolName) {
-      alert('학교 이름을 입력해주세요.');
+    if (errorMessage) {
+      alert(errorMessage);
       return;
     }
 
-    if (!domain) {
-      alert('사용하시는 학교 이메일을 입력해주세요.');
-      return;
+    if (schoolNameRef.current) {
+      schoolNameRef.current.value = schoolName;
     }
 
-    const result = `
-    ### [도메인 추가 요청]
-    - 학교명: ${schoolName}
-    - 도메인/이메일: ${domain}
-    `;
+    if (domainRef.current) {
+      domainRef.current.value = emailOrDomain;
+    }
+
+    const result = getRequestDomainPopupResult(schoolName, emailOrDomain);
 
     sendUserPopupResult(result);
     alert('요청이 접수되었습니다. 감사합니다.');

--- a/src/components/user/email/RequestDomainPopup.tsx
+++ b/src/components/user/email/RequestDomainPopup.tsx
@@ -69,7 +69,7 @@ interface RequestDomainPopupProps {
 }
 
 function RequestDomainPopup({ onClose }: RequestDomainPopupProps) {
-  const { sendPopupResult } = usePopup();
+  const { sendUserPopupResult } = usePopup();
 
   const schoolNameRef = useRef<HTMLInputElement>(null);
   const domainRef = useRef<HTMLInputElement>(null);
@@ -94,7 +94,7 @@ function RequestDomainPopup({ onClose }: RequestDomainPopupProps) {
     - 도메인/이메일: ${domain}
     `;
 
-    sendPopupResult(result);
+    sendUserPopupResult(result);
     alert('요청이 접수되었습니다. 감사합니다.');
     onClose();
   };

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -4,11 +4,15 @@ import { addDays, startOfDay } from 'date-fns';
 import useApi from '@hooks/useApi';
 
 function usePopup() {
-  const { adminApi } = useApi();
+  const { adminApi, userApi } = useApi();
   const [isOpen, setIsOpen] = useState(false);
 
-  const sendPopupResult = (result: string) => {
+  const sendAdminPopupResult = (result: string) => {
     adminApi.post('/discord/popup', { result });
+  };
+
+  const sendUserPopupResult = (result: string) => {
+    userApi.post('/discord/popup', { result });
   };
 
   const isValidPopup = (popupId: number, expireDate: Date) => {
@@ -50,12 +54,13 @@ function usePopup() {
 
   return {
     isOpen,
-    sendPopupResult,
     openPopup,
     closePopup,
     closePopupForDay,
     closePopupForever,
     isValidPopup,
+    sendAdminPopupResult,
+    sendUserPopupResult,
   };
 }
 

--- a/src/utils/requestDomainPopup.ts
+++ b/src/utils/requestDomainPopup.ts
@@ -1,0 +1,71 @@
+import { match } from 'ts-pattern';
+
+const CONTROL_CHARACTER_REGEX = /[\r\n\t]/;
+const SCHOOL_NAME_MAX_LENGTH = 50;
+const EMAIL_OR_DOMAIN_MAX_LENGTH = 100;
+
+interface RequestDomainPopupValidationResult {
+  schoolName: string;
+  emailOrDomain: string;
+  errorMessage: string | null;
+}
+
+function normalizeInput(value: string | undefined) {
+  return value?.trim() ?? '';
+}
+
+function getValidationError(value: string, emptyMessage: string, controlCharacterMessage: string, maxLengthMessage: string, maxLength: number) {
+  return match(value)
+    .when(
+      (currentValue) => currentValue === '',
+      () => emptyMessage,
+    )
+    .when(
+      (currentValue) => CONTROL_CHARACTER_REGEX.test(currentValue),
+      () => controlCharacterMessage,
+    )
+    .when(
+      (currentValue) => currentValue.length > maxLength,
+      () => maxLengthMessage,
+    )
+    .otherwise(() => null);
+}
+
+export function validateRequestDomainPopupForm(rawSchoolName: string | undefined, rawEmailOrDomain: string | undefined): RequestDomainPopupValidationResult {
+  const schoolName = normalizeInput(rawSchoolName);
+  const emailOrDomain = normalizeInput(rawEmailOrDomain);
+
+  const schoolNameError = getValidationError(
+    schoolName,
+    '학교 이름을 입력해주세요.',
+    '학교 이름에는 줄바꿈이나 탭을 입력할 수 없습니다.',
+    `학교 이름은 ${SCHOOL_NAME_MAX_LENGTH}자 이하로 입력해주세요.`,
+    SCHOOL_NAME_MAX_LENGTH,
+  );
+
+  if (schoolNameError) {
+    return { schoolName, emailOrDomain, errorMessage: schoolNameError };
+  }
+
+  const emailOrDomainError = getValidationError(
+    emailOrDomain,
+    '사용하시는 학교 이메일 또는 도메인을 입력해주세요.',
+    '이메일 또는 도메인에는 줄바꿈이나 탭을 입력할 수 없습니다.',
+    `이메일 또는 도메인은 ${EMAIL_OR_DOMAIN_MAX_LENGTH}자 이하로 입력해주세요.`,
+    EMAIL_OR_DOMAIN_MAX_LENGTH,
+  );
+
+  if (emailOrDomainError) {
+    return { schoolName, emailOrDomain, errorMessage: emailOrDomainError };
+  }
+
+  return { schoolName, emailOrDomain, errorMessage: null };
+}
+
+export function getRequestDomainPopupResult(schoolName: string, emailOrDomain: string) {
+  return `
+    ### [도메인 추가 요청]
+    - 학교명: ${schoolName}
+    - 도메인/이메일: ${emailOrDomain}
+    `;
+}


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

로그인 전에도 학교 이메일 도메인 추가 요청 팝업을 전송할 수 있도록 사용자 popup API 경로를 추가했습니다.

- `usePopup`에 `sendUserPopupResult`, `sendAdminPopupResult`를 분리해 user/admin 전송 경로를 각각 유지
- `RequestDomainPopup`이 사용자 popup API를 사용하도록 변경
- 도메인 요청용 Discord 메시지 생성 및 입력 검증 로직을 `requestDomainPopup` util로 분리
- 프론트 입력값에 대해 trim, 빈값, 줄바꿈/탭, 최대 길이 검증 추가

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)