### PR TITLE
ADD - 테이블 Hash 기반 주문 생성 적용

### DIFF
--- a/src/components/admin/order/table-manage/qrcode/TableQRCode.tsx
+++ b/src/components/admin/order/table-manage/qrcode/TableQRCode.tsx
@@ -78,7 +78,7 @@ interface TableQRCodeProps {
 }
 
 function TableQRCode({ workspaceId, selectedTable }: TableQRCodeProps) {
-  const qrCodeUrl = `${location.origin}/order?workspaceId=${workspaceId}&tableNo=${selectedTable.tableNumber}`;
+  const qrCodeUrl = `${location.origin}/order?workspaceId=${workspaceId}&tableNo=${selectedTable.tableNumber}&tableHash=${selectedTable.tableHash}`;
 
   const onClickDownloadQRCode = async () => {
     try {

--- a/src/hooks/user/useOrder.tsx
+++ b/src/hooks/user/useOrder.tsx
@@ -12,10 +12,11 @@ function useOrder() {
       .catch(() => defaultUserOrderValue);
   };
 
-  const createOrder = (workspaceId: string | null, tableNumber: string | null, orderProducts: OrderProductBase[], customerName: string) => {
+  const createOrder = (workspaceId: string | null, tableNumber: string | null, tableHash: string | null, orderProducts: OrderProductBase[], customerName: string) => {
     return userApi.post<Order>('/order', {
       workspaceId,
       tableNumber,
+      tableHash,
       orderProducts,
       customerName,
     });

--- a/src/pages/user/order/Order.tsx
+++ b/src/pages/user/order/Order.tsx
@@ -65,6 +65,7 @@ function Order() {
   const [searchParams] = useSearchParams();
   const workspaceId = searchParams.get('workspaceId');
   const tableNo = searchParams.get('tableNo');
+  const tableHash = searchParams.get('tableHash');
   const isPreview = searchParams.get('preview') === 'true';
 
   const { fetchWorkspace } = useWorkspace();
@@ -130,6 +131,7 @@ function Order() {
             search: createSearchParams({
               workspaceId: workspaceId || '',
               tableNo: tableNo || '',
+              tableHash: tableHash || '',
             }).toString(),
           });
         }}

--- a/src/pages/user/order/OrderBasket.tsx
+++ b/src/pages/user/order/OrderBasket.tsx
@@ -83,6 +83,7 @@ function OrderBasket() {
   const [searchParams] = useSearchParams();
   const workspaceId = searchParams.get('workspaceId');
   const tableNo = searchParams.get('tableNo');
+  const tableHash = searchParams.get('tableHash');
 
   const { createOrder } = useOrder();
 
@@ -105,11 +106,22 @@ function OrderBasket() {
       navigate(-1);
       return;
     }
+
+    if (error.response?.status === HttpStatusCode.NotFound) {
+      if (error.response?.data?.message === '존재하지 않는 태이블입니다.') {
+        alert('유효하지 않은 테이블입니다. QR 코드를 다시 스캔해주세요.');
+        return;
+      }
+      alert('존재하지 않는 상품이 있습니다. 주문 화면으로 돌아갑니다.');
+      setOrderBasket([]);
+      navigate(-1);
+      return;
+    }
   };
 
   const navigateHandler = () => {
     if (totalAmount === 0) {
-      createOrder(workspaceId, tableNo, orderBasket, '0원 주문')
+      createOrder(workspaceId, tableNo, tableHash, orderBasket, '0원 주문')
         .then((res) => {
           navigate({
             pathname: '/order-complete',
@@ -117,6 +129,7 @@ function OrderBasket() {
               orderId: res.data.id.toString(),
               workspaceId: workspaceId || '',
               tableNo: tableNo || '',
+              tableHash: tableHash || '',
             }).toString(),
           });
         })
@@ -130,6 +143,7 @@ function OrderBasket() {
       search: createSearchParams({
         workspaceId: workspaceId || '',
         tableNo: tableNo || '',
+        tableHash: tableHash || '',
       }).toString(),
     });
   };

--- a/src/pages/user/order/OrderBasket.tsx
+++ b/src/pages/user/order/OrderBasket.tsx
@@ -100,7 +100,7 @@ function OrderBasket() {
   };
 
   const errorHandler = (error: any) => {
-    if (error.response.status === HttpStatusCode.NotAcceptable) {
+    if (error.response?.status === HttpStatusCode.NotAcceptable) {
       alert('품절된 상품이 있습니다. 주문 화면으로 돌아갑니다.');
       setOrderBasket([]);
       navigate(-1);

--- a/src/pages/user/order/OrderComplete.tsx
+++ b/src/pages/user/order/OrderComplete.tsx
@@ -114,6 +114,7 @@ function OrderComplete() {
   const orderId = searchParams.get('orderId');
   const workspaceId = searchParams.get('workspaceId');
   const tableNo = searchParams.get('tableNo');
+  const tableHash = searchParams.get('tableHash');
 
   const { fetchOrder } = useOrder();
   const { allowPullToRefresh } = useRefresh();
@@ -248,6 +249,7 @@ function OrderComplete() {
             search: createSearchParams({
               workspaceId: workspaceId || '',
               tableNo: tableNo || '',
+              tableHash: tableHash || '',
             }).toString(),
           })
         }

--- a/src/pages/user/order/OrderPay.tsx
+++ b/src/pages/user/order/OrderPay.tsx
@@ -53,6 +53,7 @@ function OrderPay() {
   const [searchParams] = useSearchParams();
   const workspaceId = searchParams.get('workspaceId');
   const tableNo = searchParams.get('tableNo');
+  const tableHash = searchParams.get('tableHash');
 
   const account = workspace.owner.account;
   const tossAccountUrl = account?.tossAccountUrl;
@@ -71,6 +72,10 @@ function OrderPay() {
     }
 
     if (error.response?.status === HttpStatusCode.NotFound) {
+      if (error.response?.data?.message === '존재하지 않는 태이블입니다.') {
+        alert('유효하지 않은 테이블입니다. QR 코드를 다시 스캔해주세요.');
+        return;
+      }
       alert('존재하지 않는 상품이 있습니다. 주문 화면으로 돌아갑니다.');
       setOrderBasket([]);
       navigate(-2);
@@ -103,7 +108,7 @@ function OrderPay() {
       tossAccountUrl,
       amount: totalAmount,
       closeDelay: 5000,
-      promise: createOrder(workspaceId, tableNo, orderBasket, customerName),
+      promise: createOrder(workspaceId, tableNo, tableHash, orderBasket, customerName),
       onSuccess: (res) => {
         navigate({
           pathname: '/order-wait',
@@ -111,6 +116,7 @@ function OrderPay() {
             orderId: res.data.id.toString(),
             workspaceId: workspaceId || '',
             tableNo: tableNo || '',
+            tableHash: tableHash || '',
             tossPay: 'true',
           }).toString(),
         });
@@ -120,7 +126,7 @@ function OrderPay() {
   };
 
   const createOrderAndNavigateToComplete = (customerName: string) => {
-    createOrder(workspaceId, tableNo, orderBasket, customerName)
+    createOrder(workspaceId, tableNo, tableHash, orderBasket, customerName)
       .then((res) => {
         navigate({
           pathname: '/order-wait',
@@ -128,6 +134,7 @@ function OrderPay() {
             orderId: res.data.id.toString(),
             workspaceId: workspaceId || '',
             tableNo: tableNo || '',
+            tableHash: tableHash || '',
             tossPay: 'false',
           }).toString(),
         });

--- a/src/pages/user/order/OrderWait.tsx
+++ b/src/pages/user/order/OrderWait.tsx
@@ -99,6 +99,7 @@ function OrderWait() {
   const [searchParams] = useSearchParams();
   const workspaceId = searchParams.get('workspaceId');
   const tableNo = searchParams.get('tableNo');
+  const tableHash = searchParams.get('tableHash');
   const orderId = searchParams.get('orderId') || null;
   const isTossPay = searchParams.get('tossPay') === 'true';
 
@@ -129,6 +130,7 @@ function OrderWait() {
           search: createSearchParams({
             workspaceId: workspaceId || '',
             tableNo: tableNo || '',
+            tableHash: tableHash || '',
           }).toString(),
         });
         return;
@@ -164,6 +166,7 @@ function OrderWait() {
         orderId: orderId || '',
         workspaceId: workspaceId || '',
         tableNo: tableNo || '',
+        tableHash: tableHash || '',
       }).toString(),
     });
   };


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Fragmentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [ ] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

테이블 번호(`tableNumber`)는 추측이 쉬워 다른 손님 테이블로 주문을 보내는 악용이 가능했습니다. 백엔드가 각 테이블에 추측 불가능한 `tableHash`(UUID v4)를 부여하도록 변경한 것에 맞춰, 프론트엔드도 새 QR/링크에 hash를 포함하고 주문 생성 API에 hash를 전달하도록 통합했습니다.

### HAPPY CASE(기존 플로우)
https://github.com/user-attachments/assets/0264c04a-7bed-4c81-800b-7943541e4b41

### UNHAPPY CASE(hash값이 변조된 경우)
https://github.com/user-attachments/assets/5aecf9f7-ead3-4591-888d-8ce877f46cfb



### 주요 변경

- **`useOrder.createOrder`** 시그니처에 `tableHash: string | null` 파라미터 추가, 요청 body에도 동봉 (백엔드 점진 전환 정책에 따라 `tableNumber`도 함께 전송)
- **손님 주문 페이지 5개** (`Order`, `OrderBasket`, `OrderPay`, `OrderWait`, `OrderComplete`) 에서 URL의 `tableHash`를 읽어 페이지 간 navigation으로 propagate
- **404 에러 핸들링** — `OrderBasket`, `OrderPay`의 `errorHandler`에서 서버 메시지 `'존재하지 않는 태이블입니다.'`(서버 오타 그대로) 정확 매칭 시 `'유효하지 않은 테이블입니다. QR 코드를 다시 스캔해주세요.'` alert + 페이지 유지 (QR 재스캔 유도)
- **어드민 QR 코드 URL** (`TableQRCode.tsx`) 에 `&tableHash=${selectedTable.tableHash}` 추가 — 새로 출력하는 QR은 hash 포함

### URL 스키마 (점진 전환)

```
Before: /order?workspaceId=1&tableNo=3
After:  /order?workspaceId=1&tableNo=3&tableHash=<uuid>
```

기존 출력된 QR(hash 없음)은 백엔드 legacy fallback이 처리하므로 끊기지 않습니다. 다만 보안 효과를 받으려면 어드민에서 새 QR 재출력이 권장됩니다.

### 부수 변경

- `OrderBasket.errorHandler` — 인접 코드 일관성을 위해 `error.response.status` → `error.response?.status` 옵셔널 체이닝 통일

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

### 상수화 미적용 (체크리스트 5번)

서버 응답 메시지(`'존재하지 않는 태이블입니다.'`)와 사용자 alert 메시지(`'유효하지 않은 테이블입니다. QR 코드를 다시 스캔해주세요.'`)가 `OrderBasket.tsx`, `OrderPay.tsx` 두 파일에 그대로 반복됩니다. 사용처가 두 곳뿐이라 inline으로 두었으나, 추후 동일 메시지를 다른 페이지에서도 검사해야 하면 `@constants/message.ts` 류로 분리 검토 가능합니다.

### 후속 검토 (이번 PR 범위 외)

- **`useTableSearchParams` 커스텀 훅** — 5개 페이지에서 `searchParams.get('workspaceId' / 'tableNo' / 'tableHash')` 패턴이 반복됩니다. 이 PR로 5개 페이지가 모두 동일한 형태로 정렬됐으니, 후속 PR에서 커스텀 훅으로 추출하기 좋은 시점입니다.
- **`tableHash`의 Sentry/외부 추적 도구 노출** — 백엔드 핸드오프 §5에서 "주의" 수준으로 언급된 항목. 현재 axios 인터셉터가 에러 시 URL을 Sentry로 전송하면 hash가 그대로 노출될 수 있습니다. 별도 보안 강화 작업으로 분리.
- **백엔드 `tableNumber` legacy 분기 제거** — 운영 매장에 새 QR 갱신이 모두 완료된 후 백엔드에 요청

### 404 분기 기준에 대한 메모

`error.response?.data?.message === '존재하지 않는 태이블입니다.'` 정확 문자열 매칭은 메시지 변경 시 깨질 수 있는 결합입니다. 더 견고한 방식(예: 백엔드의 안정된 `errorCode` 필드)은 별도 논의가 필요해 이번 스코프에서는 제외했습니다.
