### PR TITLE
ADD - 4월 30일 이전 QR코드 작동 안내 팝업 추가

### DIFF
--- a/src/components/admin/home/OrderQRNoticePopupContent.tsx
+++ b/src/components/admin/home/OrderQRNoticePopupContent.tsx
@@ -1,38 +1,47 @@
 import styled from '@emotion/styled';
-import { Color } from '@resources/colors';
 import { colFlex } from '@styles/flexStyles';
 
 const Container = styled.div`
   width: 100%;
+  height: 100%;
   box-sizing: border-box;
-  gap: 20px;
+  gap: 32px;
+  ${colFlex({ justify: 'center', align: 'center' })};
+`;
+
+const Icon = styled.div`
+  width: 100px;
+  height: 100px;
+  border-radius: 60px;
+  background: #fff3c9;
+  font-size: 45px;
   ${colFlex({ justify: 'center', align: 'center' })};
 `;
 
 const Title = styled.div`
-  color: ${Color.BLACK};
   text-align: center;
   word-break: keep-all;
   font-size: 24px;
   font-weight: 700;
   line-height: 1.4;
+  white-space: pre-wrap;
 `;
 
 const Description = styled.div`
-  color: ${Color.BLACK};
   text-align: center;
   word-break: keep-all;
   font-size: 16px;
   font-weight: 400;
   line-height: 1.6;
-  opacity: 0.72;
+  opacity: 0.56;
   white-space: pre-wrap;
 `;
 
-function OrderQrNoticePopupContent() {
+function OrderQRNoticePopupContent() {
   return (
     <Container>
-      <Title>4월 30일 이전에 다운로드한 주문 QR 코드는 작동하지 않습니다.</Title>
+      <Icon>⚠️</Icon>
+      <Title>4월 30일 이전에 다운로드한 주문 QR 코드는{'\n'}작동하지 않습니다.</Title>
       <Description>
         주문을 받으려면 주문 QR 코드를 다시 다운로드해 주세요.
         {'\n'}
@@ -42,4 +51,4 @@ function OrderQrNoticePopupContent() {
   );
 }
 
-export default OrderQrNoticePopupContent;
+export default OrderQRNoticePopupContent;

--- a/src/components/admin/home/OrderQRNoticePopupContent.tsx
+++ b/src/components/admin/home/OrderQRNoticePopupContent.tsx
@@ -5,23 +5,23 @@ const Container = styled.div`
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  gap: 32px;
+  gap: 14px;
   ${colFlex({ justify: 'center', align: 'center' })};
 `;
 
 const Icon = styled.div`
-  width: 100px;
-  height: 100px;
-  border-radius: 60px;
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
   background: #fff3c9;
-  font-size: 45px;
+  font-size: 20px;
   ${colFlex({ justify: 'center', align: 'center' })};
 `;
 
 const Title = styled.div`
   text-align: center;
   word-break: keep-all;
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 700;
   line-height: 1.4;
   white-space: pre-wrap;
@@ -30,9 +30,9 @@ const Title = styled.div`
 const Description = styled.div`
   text-align: center;
   word-break: keep-all;
-  font-size: 16px;
+  font-size: 12px;
   font-weight: 400;
-  line-height: 1.6;
+  line-height: 1.45;
   opacity: 0.56;
   white-space: pre-wrap;
 `;
@@ -41,7 +41,7 @@ function OrderQRNoticePopupContent() {
   return (
     <Container>
       <Icon>⚠️</Icon>
-      <Title>4월 30일 이전에 다운로드한 주문 QR 코드는{'\n'}작동하지 않습니다.</Title>
+      <Title>4월 30일 이전에 다운로드한 {'\n'}주문 QR 코드는 작동하지 않습니다.</Title>
       <Description>
         주문을 받으려면 주문 QR 코드를 다시 다운로드해 주세요.
         {'\n'}

--- a/src/components/admin/home/OrderQrNoticePopupContent.tsx
+++ b/src/components/admin/home/OrderQrNoticePopupContent.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import { Color } from '@resources/colors';
+import { colFlex } from '@styles/flexStyles';
+
+const Container = styled.div`
+  width: 100%;
+  box-sizing: border-box;
+  gap: 20px;
+  ${colFlex({ justify: 'center', align: 'center' })};
+`;
+
+const Title = styled.div`
+  color: ${Color.BLACK};
+  text-align: center;
+  word-break: keep-all;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.4;
+`;
+
+const Description = styled.div`
+  color: ${Color.BLACK};
+  text-align: center;
+  word-break: keep-all;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.6;
+  opacity: 0.72;
+  white-space: pre-wrap;
+`;
+
+function OrderQrNoticePopupContent() {
+  return (
+    <Container>
+      <Title>4월 30일 이전에 다운로드한 주문 QR 코드는 작동하지 않습니다.</Title>
+      <Description>
+        주문을 받으려면 주문 QR 코드를 다시 다운로드해 주세요.
+        {'\n'}
+        기존에 저장해둔 QR 이미지는 삭제 후 새 QR로 교체해 주세요.
+      </Description>
+    </Container>
+  );
+}
+
+export default OrderQrNoticePopupContent;

--- a/src/components/common/popup/AppPopup.tsx
+++ b/src/components/common/popup/AppPopup.tsx
@@ -13,21 +13,28 @@ const Container = styled.div`
   background: transparent;
   z-index: 9999;
   position: fixed;
+  inset: 0;
+  pointer-events: none;
 `;
 
 const SubContainer = styled.div`
   width: 100%;
   height: 100%;
-  ${colFlex({ justify: 'center', align: 'center' })};
+  padding: 88px 32px 0 32px;
+  box-sizing: border-box;
+  pointer-events: none;
+  ${colFlex({ justify: 'flex-start', align: 'flex-end' })};
 `;
 
 const ContentContainer = styled.div`
-  width: 600px;
+  width: 420px;
+  max-width: 100%;
   border-radius: 16px;
-  padding: 32px;
+  padding: 24px;
   border: 1px solid rgba(0, 0, 0, 0.1);
   background: ${Color.WHITE};
-  box-shadow: 3px 3px 10px 0 rgba(0, 0, 0, 0.05);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.16);
+  pointer-events: auto;
   ${colFlex({ justify: 'center', align: 'center' })};
 `;
 

--- a/src/components/common/popup/AppPopup.tsx
+++ b/src/components/common/popup/AppPopup.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { RiCloseCircleFill } from '@remixicon/react';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
-import { PopupData } from '@constants/data/popupData';
+import { POPUP_CLOSE_MODE, PopupData } from '@constants/data/popupData';
 import { useCookies } from 'react-cookie';
 
 const Container = styled.div`
@@ -66,7 +66,7 @@ interface AppPopupProps {
 }
 
 function AppPopup({ popupDatas }: AppPopupProps) {
-  const { isValidPopup, closePopupForDay } = usePopup();
+  const { isValidPopup, closePopupForDay, closePopupForever } = usePopup();
   const [validPopupData, setValidPopupData] = useState<PopupData | null>(popupDatas[0]);
   const [cookies] = useCookies();
 
@@ -85,18 +85,24 @@ function AppPopup({ popupDatas }: AppPopupProps) {
     return null;
   }
 
-  const { popupId, children } = validPopupData;
+  const { popupId, expireDate, children, closeMode = POPUP_CLOSE_MODE.DAY, closeText } = validPopupData;
+  const popupCloseText = closeText ?? (closeMode === POPUP_CLOSE_MODE.FOREVER ? '다시 보지 않기' : '하루 동안 보지 않기');
+
+  const handleClosePopup = () => {
+    if (closeMode === POPUP_CLOSE_MODE.FOREVER) {
+      closePopupForever(popupId, expireDate);
+      return;
+    }
+
+    closePopupForDay(popupId);
+  };
 
   return (
     <Container>
       <SubContainer>
         <ContentContainer>
-          <CloseButtonContainer
-            onClick={() => {
-              closePopupForDay(popupId);
-            }}
-          >
-            <CloseText>하루 동안 보지 않기</CloseText>
+          <CloseButtonContainer onClick={handleClosePopup}>
+            <CloseText>{popupCloseText}</CloseText>
             <CloseButtonIcon />
           </CloseButtonContainer>
           {children}

--- a/src/components/common/popup/AppPopup.tsx
+++ b/src/components/common/popup/AppPopup.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { RiCloseCircleFill } from '@remixicon/react';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { Color } from '@resources/colors';
-import { PopupData, popupDatas } from '@constants/data/popupData';
+import { PopupData } from '@constants/data/popupData';
 import { useCookies } from 'react-cookie';
 
 const Container = styled.div`
@@ -54,7 +54,11 @@ const CloseButtonIcon = styled(RiCloseCircleFill)`
   color: #e0e0e0;
 `;
 
-function AppPopup() {
+interface AppPopupProps {
+  popupDatas: PopupData[];
+}
+
+function AppPopup({ popupDatas }: AppPopupProps) {
   const { isValidPopup, closePopupForDay } = usePopup();
   const [validPopupData, setValidPopupData] = useState<PopupData | null>(popupDatas[0]);
   const [cookies] = useCookies();
@@ -68,7 +72,7 @@ function AppPopup() {
     }
 
     setValidPopupData(popupDatas[index]);
-  }, [cookies]);
+  }, [cookies, isValidPopup, popupDatas]);
 
   if (!validPopupData) {
     return null;

--- a/src/components/common/popup/AppPopup.tsx
+++ b/src/components/common/popup/AppPopup.tsx
@@ -85,11 +85,11 @@ function AppPopup({ popupDatas }: AppPopupProps) {
     return null;
   }
 
-  const { popupId, expireDate, children, closeMode = POPUP_CLOSE_MODE.DAY, closeText } = validPopupData;
+  const { popupId, children, closeMode = POPUP_CLOSE_MODE.DAY, closeText } = validPopupData;
   const popupCloseText = closeText ?? (closeMode === POPUP_CLOSE_MODE.FOREVER ? '다시 보지 않기' : '하루 동안 보지 않기');
 
   const handleClosePopup = () => {
-    closePopup(popupId, closeMode, expireDate);
+    closePopup(popupId, closeMode);
   };
 
   return (

--- a/src/components/common/popup/AppPopup.tsx
+++ b/src/components/common/popup/AppPopup.tsx
@@ -66,7 +66,7 @@ interface AppPopupProps {
 }
 
 function AppPopup({ popupDatas }: AppPopupProps) {
-  const { isValidPopup, closePopupForDay, closePopupForever } = usePopup();
+  const { isValidPopup, closePopup } = usePopup();
   const [validPopupData, setValidPopupData] = useState<PopupData | null>(popupDatas[0]);
   const [cookies] = useCookies();
 
@@ -89,12 +89,7 @@ function AppPopup({ popupDatas }: AppPopupProps) {
   const popupCloseText = closeText ?? (closeMode === POPUP_CLOSE_MODE.FOREVER ? '다시 보지 않기' : '하루 동안 보지 않기');
 
   const handleClosePopup = () => {
-    if (closeMode === POPUP_CLOSE_MODE.FOREVER) {
-      closePopupForever(popupId, expireDate);
-      return;
-    }
-
-    closePopupForDay(popupId);
+    closePopup(popupId, closeMode, expireDate);
   };
 
   return (

--- a/src/components/common/popup/popup-content/PopupContent1.tsx
+++ b/src/components/common/popup/popup-content/PopupContent1.tsx
@@ -4,6 +4,7 @@ import { colFlex } from '@styles/flexStyles';
 import NewAppInput from '@components/common/input/NewAppInput';
 import NewCommonButton from '@components/common/button/NewCommonButton';
 import usePopup from '@hooks/usePopup';
+import { POPUP_CLOSE_MODE } from '@constants/data/popupData';
 
 const Container = styled.div`
   width: 100%;
@@ -37,7 +38,7 @@ const Description = styled.div`
 `;
 
 function PopupContent1() {
-  const { sendAdminPopupResult, closePopupForever } = usePopup();
+  const { sendAdminPopupResult, closePopup } = usePopup();
 
   const title = '키오스쿨 사용 인터뷰에 참여해주세요!';
   const description =
@@ -63,7 +64,7 @@ function PopupContent1() {
 
     sendAdminPopupResult(result);
 
-    closePopupForever(1);
+    closePopup(1, POPUP_CLOSE_MODE.FOREVER);
   };
 
   return (

--- a/src/constants/data/popupData.tsx
+++ b/src/constants/data/popupData.tsx
@@ -3,7 +3,7 @@ import PopupContent1 from '@components/common/popup/popup-content/PopupContent1'
 export interface PopupData {
   popupId: number;
   title: string;
-  expireDate: Date;
+  expireDate?: Date;
   children: React.ReactNode;
 }
 

--- a/src/constants/data/popupData.tsx
+++ b/src/constants/data/popupData.tsx
@@ -1,10 +1,19 @@
 import PopupContent1 from '@components/common/popup/popup-content/PopupContent1';
 
+export const POPUP_CLOSE_MODE = {
+  DAY: 'DAY',
+  FOREVER: 'FOREVER',
+} as const;
+
+export type PopupCloseMode = typeof POPUP_CLOSE_MODE[keyof typeof POPUP_CLOSE_MODE];
+
 export interface PopupData {
   popupId: number;
   title: string;
   expireDate: Date;
   children: React.ReactNode;
+  closeMode?: PopupCloseMode;
+  closeText?: string;
 }
 
 export const popupDatas: PopupData[] = [

--- a/src/constants/data/popupData.tsx
+++ b/src/constants/data/popupData.tsx
@@ -3,7 +3,7 @@ import PopupContent1 from '@components/common/popup/popup-content/PopupContent1'
 export interface PopupData {
   popupId: number;
   title: string;
-  expireDate?: Date;
+  expireDate: Date;
   children: React.ReactNode;
 }
 

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -15,13 +15,17 @@ function usePopup() {
     userApi.post('/discord/popup', { result });
   };
 
-  const isValidPopup = (popupId: number, expireDate: Date) => {
+  const isValidPopup = (popupId: number, expireDate?: Date) => {
     const cookies = new Cookies();
     const currentDate = new Date();
 
     const cookie = cookies.get(`close_popup_${popupId}`);
     if (cookie) {
       return false;
+    }
+
+    if (!expireDate) {
+      return true;
     }
 
     return expireDate >= currentDate;

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -15,17 +15,13 @@ function usePopup() {
     userApi.post('/discord/popup', { result });
   };
 
-  const isValidPopup = (popupId: number, expireDate?: Date) => {
+  const isValidPopup = (popupId: number, expireDate: Date) => {
     const cookies = new Cookies();
     const currentDate = new Date();
 
     const cookie = cookies.get(`close_popup_${popupId}`);
     if (cookie) {
       return false;
-    }
-
-    if (!expireDate) {
-      return true;
     }
 
     return expireDate >= currentDate;

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -46,9 +46,9 @@ function usePopup() {
     closePopup();
   };
 
-  const closePopupForever = (popupId: number) => {
+  const closePopupForever = (popupId: number, expireDate?: Date) => {
     const cookies = new Cookies();
-    cookies.set(`close_popup_${popupId}`, 'true', { path: '/' });
+    cookies.set(`close_popup_${popupId}`, 'true', { path: '/', expires: expireDate });
     closePopup();
   };
 

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Cookies } from 'react-cookie';
 import { addDays, startOfDay } from 'date-fns';
 import useApi from '@hooks/useApi';
+import { POPUP_CLOSE_MODE, PopupCloseMode } from '@constants/data/popupData';
 
 const DEFAULT_POPUP_COOKIE_EXPIRE_DATE = new Date(9999, 11, 31);
 
@@ -35,7 +36,7 @@ function usePopup() {
     document.body.style.overflow = 'hidden';
   };
 
-  const closePopup = () => {
+  const closePopupModal = () => {
     setIsOpen(false);
     // 팝업창 close 시 배경 스크롤 금지 해제 코드
     document.body.style.overflow = 'auto';
@@ -45,21 +46,33 @@ function usePopup() {
     const cookies = new Cookies();
     const expireDate = startOfDay(addDays(new Date(), 1));
     cookies.set(`close_popup_${popupId}`, 'true', { path: '/', expires: expireDate });
-    closePopup();
+    closePopupModal();
   };
 
   const closePopupForever = (popupId: number, expireDate?: Date) => {
     const cookies = new Cookies();
     cookies.set(`close_popup_${popupId}`, 'true', { path: '/', expires: expireDate ?? DEFAULT_POPUP_COOKIE_EXPIRE_DATE });
-    closePopup();
+    closePopupModal();
+  };
+
+  const closePopup = (popupId?: number, closeMode?: PopupCloseMode, expireDate?: Date) => {
+    if (popupId === undefined || closeMode === undefined) {
+      closePopupModal();
+      return;
+    }
+
+    if (closeMode === POPUP_CLOSE_MODE.FOREVER) {
+      closePopupForever(popupId, expireDate);
+      return;
+    }
+
+    closePopupForDay(popupId);
   };
 
   return {
     isOpen,
     openPopup,
     closePopup,
-    closePopupForDay,
-    closePopupForever,
     isValidPopup,
     sendAdminPopupResult,
     sendUserPopupResult,

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -49,20 +49,20 @@ function usePopup() {
     closePopupModal();
   };
 
-  const closePopupForever = (popupId: number, expireDate?: Date) => {
+  const closePopupForever = (popupId: number) => {
     const cookies = new Cookies();
-    cookies.set(`close_popup_${popupId}`, 'true', { path: '/', expires: expireDate ?? DEFAULT_POPUP_COOKIE_EXPIRE_DATE });
+    cookies.set(`close_popup_${popupId}`, 'true', { path: '/', expires: DEFAULT_POPUP_COOKIE_EXPIRE_DATE });
     closePopupModal();
   };
 
-  const closePopup = (popupId?: number, closeMode?: PopupCloseMode, expireDate?: Date) => {
+  const closePopup = (popupId?: number, closeMode?: PopupCloseMode) => {
     if (popupId === undefined || closeMode === undefined) {
       closePopupModal();
       return;
     }
 
     if (closeMode === POPUP_CLOSE_MODE.FOREVER) {
-      closePopupForever(popupId, expireDate);
+      closePopupForever(popupId);
       return;
     }
 

--- a/src/hooks/usePopup.tsx
+++ b/src/hooks/usePopup.tsx
@@ -3,6 +3,8 @@ import { Cookies } from 'react-cookie';
 import { addDays, startOfDay } from 'date-fns';
 import useApi from '@hooks/useApi';
 
+const DEFAULT_POPUP_COOKIE_EXPIRE_DATE = new Date(9999, 11, 31);
+
 function usePopup() {
   const { adminApi, userApi } = useApi();
   const [isOpen, setIsOpen] = useState(false);
@@ -48,7 +50,7 @@ function usePopup() {
 
   const closePopupForever = (popupId: number, expireDate?: Date) => {
     const cookies = new Cookies();
-    cookies.set(`close_popup_${popupId}`, 'true', { path: '/', expires: expireDate });
+    cookies.set(`close_popup_${popupId}`, 'true', { path: '/', expires: expireDate ?? DEFAULT_POPUP_COOKIE_EXPIRE_DATE });
     closePopup();
   };
 

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -5,7 +5,7 @@ import AddWorkspace from '@components/common/workspace/AddWorkspace';
 import WorkspaceContent from '@components/admin/workspace/WorkspaceContent';
 import HomeOnboarding from '@components/admin/home/HomeOnboarding';
 import AppPopup from '@components/common/popup/AppPopup';
-import { PopupData } from '@constants/data/popupData';
+import { POPUP_CLOSE_MODE, PopupData } from '@constants/data/popupData';
 import { colFlex } from '@styles/flexStyles';
 import { useAtomValue } from 'jotai';
 import { adminUserAtom, adminWorkspacesAtom } from '@jotai/admin/atoms';
@@ -30,6 +30,8 @@ const ADMIN_HOME_POPUP_DATAS: PopupData[] = [
     title: '주문 QR 코드 재다운로드 안내',
     expireDate: new Date(2026, 5, 5),
     children: <OrderQRNoticePopupContent />,
+    closeMode: POPUP_CLOSE_MODE.FOREVER,
+    closeText: '다시 보지 않기',
   },
 ];
 

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -4,6 +4,9 @@ import AppContainer from '@components/common/container/AppContainer';
 import AddWorkspace from '@components/common/workspace/AddWorkspace';
 import WorkspaceContent from '@components/admin/workspace/WorkspaceContent';
 import HomeOnboarding from '@components/admin/home/HomeOnboarding';
+import OrderQrNoticePopupContent from '@components/admin/home/OrderQrNoticePopupContent';
+import AppPopup from '@components/common/popup/AppPopup';
+import { PopupData } from '@constants/data/popupData';
 import { colFlex } from '@styles/flexStyles';
 import { useAtomValue } from 'jotai';
 import { adminUserAtom, adminWorkspacesAtom } from '@jotai/admin/atoms';
@@ -14,6 +17,20 @@ const Container = styled.div`
   width: 95%;
   ${colFlex({ align: 'center' })}
 `;
+
+const ADMIN_HOME_POPUP_DATAS: PopupData[] = [
+  {
+    popupId: 0,
+    title: 'Default Popup for prevent flickering',
+    expireDate: new Date(1000, 1, 1),
+    children: null,
+  },
+  {
+    popupId: 2,
+    title: '주문 QR 코드 재다운로드 안내',
+    children: <OrderQrNoticePopupContent />,
+  },
+];
 
 function AdminHome() {
   const { fetchWorkspaces, fetchAdminUser } = useAdminUser();
@@ -27,24 +44,25 @@ function AdminHome() {
     fetchAdminUser();
   }, []);
 
-  if (!isAccountRegistered) {
-    return (
-      <AppContainer useFlex={colFlex({ justify: 'center', align: 'center' })} customGap={'30px'}>
-        <HomeOnboarding />
-      </AppContainer>
-    );
-  }
+  const pageContent = !isAccountRegistered ? (
+    <HomeOnboarding />
+  ) : (
+    <Container>
+      <WorkspaceContent workspaces={workspaces}>
+        {Array.from({ length: addWorkspaceNumber }).map((_, i) => (
+          <AddWorkspace key={i} workspaces={workspaces} />
+        ))}
+      </WorkspaceContent>
+      <AppFaqButton />
+    </Container>
+  );
 
   return (
     <AppContainer useFlex={colFlex({ justify: 'center', align: 'center' })} customGap={'30px'}>
-      <Container>
-        <WorkspaceContent workspaces={workspaces}>
-          {Array.from({ length: addWorkspaceNumber }).map((_, i) => (
-            <AddWorkspace key={i} workspaces={workspaces} />
-          ))}
-        </WorkspaceContent>
-        <AppFaqButton />
-      </Container>
+      <>
+        {pageContent}
+        <AppPopup popupDatas={ADMIN_HOME_POPUP_DATAS} />
+      </>
     </AppContainer>
   );
 }

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -11,7 +11,7 @@ import { useAtomValue } from 'jotai';
 import { adminUserAtom, adminWorkspacesAtom } from '@jotai/admin/atoms';
 import AppFaqButton from '@components/common/button/AppFaqButton';
 import styled from '@emotion/styled';
-import OrderQRNoticePopupContent from '@components/admin/home/OrderQrNoticePopupContent';
+import OrderQRNoticePopupContent from '@components/admin/home/OrderQRNoticePopupContent';
 
 const Container = styled.div`
   width: 95%;
@@ -28,7 +28,7 @@ const ADMIN_HOME_POPUP_DATAS: PopupData[] = [
   {
     popupId: 2,
     title: '주문 QR 코드 재다운로드 안내',
-    expireDate: new Date(2026, 5, 5, 23, 59, 59, 999),
+    expireDate: new Date(2026, 5, 5),
     children: <OrderQRNoticePopupContent />,
   },
 ];

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import useAdminUser from '@hooks/admin/useAdminUser';
 import AppContainer from '@components/common/container/AppContainer';
 import AddWorkspace from '@components/common/workspace/AddWorkspace';
@@ -16,6 +16,14 @@ import OrderQRNoticePopupContent from '@components/admin/home/OrderQRNoticePopup
 const Container = styled.div`
   width: 95%;
   ${colFlex({ align: 'center' })}
+`;
+
+const LoadingContainer = styled.div`
+  width: 100%;
+  min-height: 320px;
+  color: #5d6368;
+  font-size: 18px;
+  ${colFlex({ justify: 'center', align: 'center' })}
 `;
 
 const ADMIN_HOME_POPUP_DATAS: PopupData[] = [
@@ -39,15 +47,20 @@ function AdminHome() {
   const { fetchWorkspaces, fetchAdminUser } = useAdminUser();
   const workspaces = useAtomValue(adminWorkspacesAtom);
   const user = useAtomValue(adminUserAtom);
+  const [isAdminUserLoading, setIsAdminUserLoading] = useState(true);
   const addWorkspaceNumber = 3 - workspaces.length;
   const isAccountRegistered = !!user.account?.accountNumber;
 
   useEffect(() => {
     fetchWorkspaces();
-    fetchAdminUser();
+    fetchAdminUser().finally(() => {
+      setIsAdminUserLoading(false);
+    });
   }, []);
 
-  const pageContent = !isAccountRegistered ? (
+  const pageContent = isAdminUserLoading ? (
+    <LoadingContainer>계정 정보를 불러오는 중입니다.</LoadingContainer>
+  ) : !isAccountRegistered ? (
     <HomeOnboarding />
   ) : (
     <Container>

--- a/src/pages/admin/AdminHome.tsx
+++ b/src/pages/admin/AdminHome.tsx
@@ -4,7 +4,6 @@ import AppContainer from '@components/common/container/AppContainer';
 import AddWorkspace from '@components/common/workspace/AddWorkspace';
 import WorkspaceContent from '@components/admin/workspace/WorkspaceContent';
 import HomeOnboarding from '@components/admin/home/HomeOnboarding';
-import OrderQrNoticePopupContent from '@components/admin/home/OrderQrNoticePopupContent';
 import AppPopup from '@components/common/popup/AppPopup';
 import { PopupData } from '@constants/data/popupData';
 import { colFlex } from '@styles/flexStyles';
@@ -12,6 +11,7 @@ import { useAtomValue } from 'jotai';
 import { adminUserAtom, adminWorkspacesAtom } from '@jotai/admin/atoms';
 import AppFaqButton from '@components/common/button/AppFaqButton';
 import styled from '@emotion/styled';
+import OrderQRNoticePopupContent from '@components/admin/home/OrderQrNoticePopupContent';
 
 const Container = styled.div`
   width: 95%;
@@ -28,7 +28,8 @@ const ADMIN_HOME_POPUP_DATAS: PopupData[] = [
   {
     popupId: 2,
     title: '주문 QR 코드 재다운로드 안내',
-    children: <OrderQrNoticePopupContent />,
+    expireDate: new Date(2026, 5, 5, 23, 59, 59, 999),
+    children: <OrderQRNoticePopupContent />,
   },
 ];
 

--- a/src/pages/admin/AdminWorkspace.tsx
+++ b/src/pages/admin/AdminWorkspace.tsx
@@ -7,6 +7,7 @@ import { colFlex, rowFlex } from '@styles/flexStyles';
 import PreviewContainer from '@components/common/container/PreviewContainer';
 import AppFaqButton from '@components/common/button/AppFaqButton';
 import AppPopup from '@components/common/popup/AppPopup';
+import { popupDatas } from '@constants/data/popupData';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { adminSideNavIsOpenAtom, adminWorkspaceAtom } from '@jotai/admin/atoms';
 import AdminDashboard from '@components/admin/workspace/dashboard/AdminDashboard';
@@ -107,7 +108,7 @@ function AdminWorkspace() {
           <AdminDashboard />
           <PreviewContainer width={300} height={640} />
         </ContentContainer>
-        <AppPopup />
+        <AppPopup popupDatas={popupDatas} />
         <AppFaqButton />
       </>
     ));


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [ ] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [ ] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

<img width="1470" height="923" alt="image" src="https://github.com/user-attachments/assets/9b75ce3d-4f5d-43d2-9bba-8c1993238a38" />

- `/admin` 진입 시 주문 QR 코드 재다운로드 안내 팝업이 노출되도록 추가했습니다.
- 사용자가 `하루 동안 보지 않기`를 선택할 수 있도록 연결했습니다.
- 홈 화면에서는 홈 전용 팝업 데이터를 사용하고, 워크스페이스 화면에서는 기존 팝업 데이터를 그대로 사용하도록 `AppPopup`을 props 기반으로 분리했습니다.
- QR 안내 팝업은 `2026년 6월 5일 23:59:59`까지 유지되도록 만료일을 설정했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- `src/components/common/popup/AppPopup.tsx`
  - 기존에는 내부에서 전역 `popupDatas`를 직접 참조했는데, 이번 변경으로 `popupDatas`를 props로 받도록 바뀌었습니다.
  - 홈과 워크스페이스에서 서로 다른 팝업 세트를 쓸 수 있게 한 구조 변경이라 이 방향이 괜찮은지 봐주시면 됩니다.

- `src/pages/admin/AdminHome.tsx`
  - 홈 전용 `ADMIN_HOME_POPUP_DATAS`를 추가했고, 여기서 QR 공지 팝업의 만료일을 `2026-06-05 23:59`로 설정했습니다.