### PR TITLE
FIX - 상품을 찾을 수 없을때 imageUrl 접근 불가로 인해 터지는 이슈 해결

### DIFF
--- a/src/components/admin/order/realtime/modal/order-detail/OrderModalMainContents.tsx
+++ b/src/components/admin/order/realtime/modal/order-detail/OrderModalMainContents.tsx
@@ -57,7 +57,7 @@ function OrderModalMainContents({ order }: OrderModalMainContentsProps) {
   const readOnly = useAtomValue(orderModalReadOnlyAtom);
 
   const products = useAtomValue(adminProductsAtom);
-  const productMap: Record<number, Product> = _.keyBy(products, 'id');
+  const productMap: Record<number, Product | undefined> = _.keyBy(products, 'id');
 
   const isPaidStatus = order.status === OrderStatus.PAID;
   const isAllServed = order.orderProducts.every((orderProduct) => orderProduct.isServed);

--- a/src/components/admin/order/realtime/modal/order-detail/OrderModalProductsList.tsx
+++ b/src/components/admin/order/realtime/modal/order-detail/OrderModalProductsList.tsx
@@ -77,7 +77,7 @@ const ProductQuantityLabel = styled.div`
 
 interface OrderModalProductListProps {
   orderProducts: OrderProduct[];
-  productMap: Record<number, Product>;
+  productMap: Record<number, Product | undefined>;
   isPaidStatus: boolean;
   onIncrease: (orderProduct: OrderProduct) => void;
   onDecrease: (orderProduct: OrderProduct) => void;
@@ -88,7 +88,7 @@ function OrderModalProductList({ orderProducts, productMap, isPaidStatus, onIncr
     <OrderProductContainer>
       {orderProducts.map((orderProduct) => {
         const product = productMap[orderProduct.productId];
-        const productImageUrl = product.imageUrl || defaultProductImage;
+        const productImageUrl = product?.imageUrl || defaultProductImage;
 
         return (
           <ProductContainer key={`${orderProduct.id}`}>


### PR DESCRIPTION
## Summary

`/admin/total-order` 페이지에서 과거 주문 모달을 열 때 `Cannot read properties of undefined (reading 'imageUrl')` Sentry 에러가 발생하던 문제를 수정합니다. 어드민이 삭제한 상품의 `productId`가 과거 주문에는 남아 있는데, 모달은 현재 활성 상품 목록(`adminProductsAtom`)에서 이미지를 lookup하기 때문에 `productMap[productId]`가 `undefined`가 되어 `.imageUrl` 접근 시 터졌습니다.

`OrderModalProductsList`의 `productMap` 타입을 `Record<number, Product | undefined>`로 좁히고 `product?.imageUrl || defaultProductImage`로 옵셔널 체이닝을 적용했습니다. 호출부 `OrderModalMainContents`의 타입도 함께 맞췄습니다. 동일 패턴인 `SessionOrderCard`가 이미 같은 방식으로 처리돼 있어 그 처리와 정렬됩니다.

이 변경은 **임시 조치**입니다. 근본 원인은 `OrderProduct`에 `productName`/`productPrice`는 스냅샷으로 박혀있지만 `productImageUrl`만 빠져 있는 데이터 모델 누락이며, 정식 해결은 백엔드에 `productImageUrl` 스냅샷 필드를 추가하는 것이 적절합니다 (별도 이슈 권장).

<img width="843" height="374" alt="image" src="https://github.com/user-attachments/assets/8cced02e-73af-48f9-a3e1-88176db6f6f4" />
