### PR TITLE
FIX - navigator.share 취소 시 AbortError 무시

### DIFF
--- a/src/components/common/fallback/MobileFallback.tsx
+++ b/src/components/common/fallback/MobileFallback.tsx
@@ -18,10 +18,14 @@ function MobileFallback() {
       return;
     }
 
-    await navigator.share({
-      title: '키오스쿨',
-      url: window.location.href,
-    });
+    try {
+      await navigator.share({
+        title: '키오스쿨',
+        url: window.location.href,
+      });
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') throw error;
+    }
   };
 
   return (

--- a/src/components/user/order/OrderStickyNavBar.tsx
+++ b/src/components/user/order/OrderStickyNavBar.tsx
@@ -87,10 +87,14 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
       return;
     }
 
-    await navigator.share({
-      title: workspaceName,
-      url: window.location.href,
-    });
+    try {
+      await navigator.share({
+        title: workspaceName,
+        url: window.location.href,
+      });
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') throw error;
+    }
   };
 
   return (


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Fragmentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

iOS Safari에서 사용자가 공유 시트를 닫으면 `navigator.share()`가 `AbortError`를 throw하는데, unhandled rejection으로 흘러가서 Sentry에 에러로 잡히고 있었습니다 ([KIO-SCHOOL-AD](https://kioschool.sentry.io/issues/7442784946/)). 사용자 취소는 정상 동작이므로 `AbortError`만 골라서 무시하도록 수정했습니다.

- `src/components/user/order/OrderStickyNavBar.tsx` — `/order` 페이지 상단 공유 버튼
- `src/components/common/fallback/MobileFallback.tsx` — PC 권장 fallback의 링크 공유 버튼

`AbortError` 이외의 에러(`NotAllowedError`, `TypeError` 등)는 그대로 throw되어 Sentry에 잡히도록 유지했습니다.

## 🕐 리뷰 예상 시간

> 3m
