### PR TITLE
FIX - 인증 폼 모바일 화면 대응

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,8 +87,9 @@ function App() {
         <Route path={SUPER_ADMIN_ROUTES.ACCOUNT_STATUS} element={<SuperAdminAccountStatus />} />
         <Route path={SUPER_ADMIN_ROUTES.ORDERS} element={<SuperAdminOrders />} />
 
+        <Route path={USER_ROUTES.LOGIN} element={<Login />} />
+
         <Route element={<PcOnlyLayout />}>
-          <Route path={USER_ROUTES.LOGIN} element={<Login />} />
           <Route path={USER_ROUTES.REGISTER} element={<Register />} />
           <Route path={USER_ROUTES.RESET_PASSWORD} element={<ResetPassword />} />
           <Route path={USER_ROUTES.EMAIL_DOMAINS} element={<UserEmailDomain />} />

--- a/src/components/common/input/NewAppInputLayout.tsx
+++ b/src/components/common/input/NewAppInputLayout.tsx
@@ -2,6 +2,7 @@
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { mobileMediaQuery } from '@styles/globalStyles';
 import { RiShareBoxLine } from '@remixicon/react';
 import NewCommonButton, { CustomButtonSize } from '@components/common/button/NewCommonButton';
 import { ButtonColor, ButtonSize } from '@@types/index';
@@ -13,8 +14,13 @@ const Container = styled.div<ContainerProps>`
     }
     return width || '500px';
   }};
+  max-width: calc(100vw - 32px);
   gap: 6px;
   ${colFlex({ justify: 'center', align: 'center' })};
+
+  ${mobileMediaQuery} {
+    width: 100%;
+  }
 `;
 
 const HeaderContainer = styled.div`

--- a/src/pages/user/Login.tsx
+++ b/src/pages/user/Login.tsx
@@ -4,6 +4,7 @@ import useAuthentication from '@hooks/useAuthentication';
 import styled from '@emotion/styled';
 import AppContainer from '@components/common/container/AppContainer';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { mobileMediaQuery } from '@styles/globalStyles';
 import NewAppInput from '@components/common/input/NewAppInput';
 import LinkLabel from '@components/common/label/LinkLabel';
 import NewCommonButton from '@components/common/button/NewCommonButton';
@@ -24,6 +25,13 @@ const ErrorMessage = styled.div`
 const LinkContainer = styled.div`
   gap: 10px;
   ${rowFlex({ justify: 'center', align: 'center' })};
+`;
+
+const SubmitButton = styled(NewCommonButton)`
+  ${mobileMediaQuery} {
+    width: 100%;
+    max-width: calc(100vw - 32px);
+  }
 `;
 
 function Login() {
@@ -61,7 +69,7 @@ function Login() {
           placeholder={'비밀번호를 입력해주세요.'}
         />
         <ErrorContainer>{errorMessage && <ErrorMessage className="error-message">{errorMessage}</ErrorMessage>}</ErrorContainer>
-        <NewCommonButton onClick={handleSubmit}>로그인</NewCommonButton>
+        <SubmitButton onClick={handleSubmit}>로그인</SubmitButton>
         <LinkContainer className={'button-container'}>
           <LinkLabel text={'비밀번호 찾기'} href={USER_ROUTES.RESET_PASSWORD} />
           <LinkLabel text={'회원가입 하기'} href={USER_ROUTES.REGISTER} />


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

Login/Register/ResetPassword 등 \`NewAppInput\`을 쓰는 인증 폼이 모바일 뷰포트(375px)에서 가로 스크롤이 생기던 문제 수정.

- \`NewAppInputLayout\` Container의 default width: 500px이 모바일 화면을 넘어 잘림 → \`max-width: calc(100vw - 32px)\` + 모바일 \`width: 100%\` 추가. 데스크탑은 기존 500px 유지.
- Login의 "로그인" 버튼이 input과 폭이 안 맞아 어색함 → \`SubmitButton = styled(NewCommonButton)\`로 모바일에서만 \`width: 100%\` 적용. 데스크탑은 기존 \`md\`(210px) 유지.

\`NewCommonButton\` 자체는 건드리지 않았어요 — 주문 카드의 "결제 완료/취소" 같은 작은 inline 버튼은 본래 크기를 유지해야 하니까 per-page wrapper로만 처리.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점

- \`src/components/common/input/NewAppInputLayout.tsx\` — \`NewAppInput\`을 사용하는 모든 화면(어드민 워크스페이스 폼 등)에 영향. 데스크탑 동작은 그대로지만 모바일에서 viewport 폭을 넘지 않도록 줄어듦.
- \`src/pages/user/Login.tsx\` — Login 단독 변경.

Register/ResetPassword에 같은 처리가 필요하면 follow-up으로 빼겠습니다.