### PR TITLE
EDIT - 주문 공유 링크 URL을 /share/{workspaceId}로 변경

### DIFF
--- a/src/components/user/order/OrderStickyNavBar.tsx
+++ b/src/components/user/order/OrderStickyNavBar.tsx
@@ -85,8 +85,14 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
   const workspaceId = searchParams.get('workspaceId');
 
   const buildShareUrl = () => {
-    if (workspaceId) return `${window.location.origin}/share/${workspaceId}`;
-    return window.location.href;
+    if (!workspaceId) return window.location.href;
+    const tableNoParam = searchParams.get('tableNo');
+    const tableHashParam = searchParams.get('tableHash');
+    const query = new URLSearchParams();
+    if (tableNoParam) query.set('tableNo', tableNoParam);
+    if (tableHashParam) query.set('tableHash', tableHashParam);
+    const qs = query.toString();
+    return `${window.location.origin}/share/${workspaceId}${qs ? `?${qs}` : ''}`;
   };
 
   const onClickShare = async () => {

--- a/src/components/user/order/OrderStickyNavBar.tsx
+++ b/src/components/user/order/OrderStickyNavBar.tsx
@@ -89,14 +89,12 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
       return;
     }
 
-    const workspaceId = searchParams.get('workspaceId');
-    const tableNo = searchParams.get('tableNo');
-    const tableHash = searchParams.get('tableHash');
-
     try {
       await navigator.share({
         title: workspaceName,
-        url: `${window.location.origin}/share/${workspaceId}?tableNo=${tableNo}&tableHash=${tableHash}`,
+        url: `${window.location.origin}/share/${searchParams.get('workspaceId')}?tableNo=${searchParams.get('tableNo')}&tableHash=${searchParams.get(
+          'tableHash',
+        )}`,
       });
     } catch (error) {
       if ((error as Error).name !== 'AbortError') throw error;

--- a/src/components/user/order/OrderStickyNavBar.tsx
+++ b/src/components/user/order/OrderStickyNavBar.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { Color } from '@resources/colors';
 import { rowFlex } from '@styles/flexStyles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { RiArrowLeftLine, RiShareForward2Fill } from '@remixicon/react';
 
 const Container = styled.div<{ isShow: boolean }>`
@@ -81,6 +81,14 @@ interface OrderStickyNavBarProps {
 
 function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tableNo, useShareButton = true }: OrderStickyNavBarProps) {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const workspaceId = searchParams.get('workspaceId');
+
+  const buildShareUrl = () => {
+    if (workspaceId) return `${window.location.origin}/share/${workspaceId}`;
+    return window.location.href;
+  };
+
   const onClickShare = async () => {
     if (!navigator.share) {
       alert('이 브라우저는 Web Share API를 지원하지 않습니다. 다른 브라우저를 사용해주세요.');
@@ -90,7 +98,7 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
     try {
       await navigator.share({
         title: workspaceName,
-        url: window.location.href,
+        url: buildShareUrl(),
       });
     } catch (error) {
       if ((error as Error).name !== 'AbortError') throw error;

--- a/src/components/user/order/OrderStickyNavBar.tsx
+++ b/src/components/user/order/OrderStickyNavBar.tsx
@@ -82,18 +82,6 @@ interface OrderStickyNavBarProps {
 function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tableNo, useShareButton = true }: OrderStickyNavBarProps) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const workspaceId = searchParams.get('workspaceId');
-
-  const buildShareUrl = () => {
-    if (!workspaceId) return window.location.href;
-    const tableNoParam = searchParams.get('tableNo');
-    const tableHashParam = searchParams.get('tableHash');
-    const query = new URLSearchParams();
-    if (tableNoParam) query.set('tableNo', tableNoParam);
-    if (tableHashParam) query.set('tableHash', tableHashParam);
-    const qs = query.toString();
-    return `${window.location.origin}/share/${workspaceId}${qs ? `?${qs}` : ''}`;
-  };
 
   const onClickShare = async () => {
     if (!navigator.share) {
@@ -101,10 +89,14 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
       return;
     }
 
+    const workspaceId = searchParams.get('workspaceId');
+    const tableNo = searchParams.get('tableNo');
+    const tableHash = searchParams.get('tableHash');
+
     try {
       await navigator.share({
         title: workspaceName,
-        url: buildShareUrl(),
+        url: `${window.location.origin}/share/${workspaceId}?tableNo=${tableNo}&tableHash=${tableHash}`,
       });
     } catch (error) {
       if ((error as Error).name !== 'AbortError') throw error;

--- a/src/components/user/order/OrderStickyNavBar.tsx
+++ b/src/components/user/order/OrderStickyNavBar.tsx
@@ -93,10 +93,15 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
     const paramTableNo = searchParams.get('tableNo');
     const paramTableHash = searchParams.get('tableHash');
 
+    const url =
+      paramWorkspaceId && paramTableNo && paramTableHash
+        ? `${window.location.origin}/share/${paramWorkspaceId}?tableNo=${paramTableNo}&tableHash=${paramTableHash}`
+        : window.location.href;
+
     try {
       await navigator.share({
         title: workspaceName,
-        url: `${window.location.origin}/share/${paramWorkspaceId}?tableNo=${paramTableNo}&tableHash=${paramTableHash}`,
+        url,
       });
     } catch (error) {
       if ((error as Error).name !== 'AbortError') throw error;

--- a/src/components/user/order/OrderStickyNavBar.tsx
+++ b/src/components/user/order/OrderStickyNavBar.tsx
@@ -89,12 +89,14 @@ function OrderStickyNavBar({ useLeftArrow = true, showNavBar, workspaceName, tab
       return;
     }
 
+    const paramWorkspaceId = searchParams.get('workspaceId');
+    const paramTableNo = searchParams.get('tableNo');
+    const paramTableHash = searchParams.get('tableHash');
+
     try {
       await navigator.share({
         title: workspaceName,
-        url: `${window.location.origin}/share/${searchParams.get('workspaceId')}?tableNo=${searchParams.get('tableNo')}&tableHash=${searchParams.get(
-          'tableHash',
-        )}`,
+        url: `${window.location.origin}/share/${paramWorkspaceId}?tableNo=${paramTableNo}&tableHash=${paramTableHash}`,
       });
     } catch (error) {
       if ((error as Error).name !== 'AbortError') throw error;


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Fragmentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

`OrderStickyNavBar` 공유 버튼이 호출하는 `navigator.share`의 url을 `window.location.href`(쿼리스트링 전체) 에서 정해진 형태인 `/share/{workspaceId}?tableNo=N&tableHash=H` 로 교체.

- 공유받은 사용자에게 보이는 URL이 정돈되고, 백엔드/Amplify가 User-Agent 기반 redirection을 걸기 좋은 형태가 됨.
- `workspaceId`는 path, `tableNo`/`tableHash`는 query — 테이블 QR로 진입한 컨텍스트(테이블 식별자)를 그대로 보존.
- 세 값 모두 `useSearchParams`로 현재 페이지 query string에서 그대로 읽어와 template literal로 조립.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점(Option)

- 변경 파일: `src/components/user/order/OrderStickyNavBar.tsx` 1개.
- `/share/:workspaceId` 라우트는 프론트에 정의하지 않음 — 웹/앱/원본 주문 페이지 분기는 백엔드 + Amplify 측 redirection 설정으로 처리.
