### PR TITLE
REFACTOR - 주점 정보 관리 validation 추가

### DIFF
--- a/src/pages/admin/AdminWorkspaceEdit.tsx
+++ b/src/pages/admin/AdminWorkspaceEdit.tsx
@@ -1,20 +1,26 @@
 import { useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import AppContainer from '@components/common/container/AppContainer';
-import styled from '@emotion/styled';
-import useAdminWorkspace from '@hooks/admin/useAdminWorkspace';
-import { colFlex, rowFlex } from '@styles/flexStyles';
-import { WorkspaceImage } from '@@types/index';
-import { extractImageIdsAndFiles, initWorkspaceImages, removeAndPushNull } from '@utils/workspaceEdit';
-import WorkspaceImageInput from '@components/admin/workspace/WorkspaceImageInput';
-import { adminWorkspaceAtom } from '@jotai/admin/atoms';
-import { useAtomValue } from 'jotai';
 import { css } from '@emotion/react';
-import NewCommonButton from '@components/common/button/NewCommonButton';
-import NewAppInput from '@components/common/input/NewAppInput';
-import NewAppTextarea from '@components/common/input/NewAppTextarea';
+import styled from '@emotion/styled';
+import { useAtomValue } from 'jotai';
+import { WorkspaceImage } from '@@types/index';
 import OnboardingStepHint from '@components/admin/workspace/onboarding/OnboardingStepHint';
 import { ONBOARDING_STEP } from '@components/admin/workspace/onboarding/onboardingData';
+import NewCommonButton from '@components/common/button/NewCommonButton';
+import AppContainer from '@components/common/container/AppContainer';
+import NewAppInput from '@components/common/input/NewAppInput';
+import NewAppTextarea from '@components/common/input/NewAppTextarea';
+import WorkspaceImageInput from '@components/admin/workspace/WorkspaceImageInput';
+import useAdminWorkspace from '@hooks/admin/useAdminWorkspace';
+import { adminWorkspaceAtom } from '@jotai/admin/atoms';
+import { colFlex, rowFlex } from '@styles/flexStyles';
+import {
+  validateWorkspaceInfoForm,
+  WORKSPACE_DESCRIPTION_MAX_LENGTH,
+  WORKSPACE_NAME_MAX_LENGTH,
+  WORKSPACE_NOTICE_MAX_LENGTH,
+} from '@utils/validateWorkspaceInfoForm';
+import { extractImageIdsAndFiles, initWorkspaceImages, removeAndPushNull } from '@utils/workspaceEdit';
 
 const containerStyle = css`
   width: 95%;
@@ -116,21 +122,24 @@ function AdminWorkspaceEdit() {
   };
 
   const handleSubmit = () => {
-    const title = titleRef.current?.value;
-    const description = descriptionRef.current?.value;
-    const notice = noticeRef.current?.value;
+    const rawTitle = titleRef.current?.value;
+    const rawDescription = descriptionRef.current?.value;
+    const rawNotice = noticeRef.current?.value;
 
-    if (!title || !title.trim()) {
-      alert('주점명을 입력해주세요.');
-      return;
-    }
-    if (!description || !description.trim()) {
-      alert('주점 설명을 입력해주세요.');
+    const { name, description, notice, errorMessage } = validateWorkspaceInfoForm(rawTitle, rawDescription, rawNotice);
+
+    if (errorMessage) {
+      if (!name) {
+        titleRef.current?.focus();
+      } else {
+        descriptionRef.current?.focus();
+      }
+      alert(errorMessage);
       return;
     }
 
     const { imageIds, imageFiles } = extractImageIdsAndFiles(displayImages);
-    updateWorkspaceInfoAndImage(Number(workspaceId), title, description, notice, imageIds, imageFiles);
+    updateWorkspaceInfoAndImage(Number(workspaceId), name, description, notice, imageIds, imageFiles);
   };
 
   return (
@@ -138,7 +147,14 @@ function AdminWorkspaceEdit() {
       <ContentContainer>
         <OnboardingStepHint step={ONBOARDING_STEP.INFO} width="95%" />
         <TitleContainer>
-          <NewAppInput label="주점명" ref={titleRef} defaultValue={workspace?.name || ''} width="100%" />
+          <NewAppInput
+            label="주점명"
+            ref={titleRef}
+            defaultValue={workspace?.name || ''}
+            placeholder={`최대 ${WORKSPACE_NAME_MAX_LENGTH}자까지 가능합니다.`}
+            maxLength={WORKSPACE_NAME_MAX_LENGTH}
+            width="100%"
+          />
         </TitleContainer>
         <ImageContainer>
           <Label>대표 사진</Label>
@@ -147,10 +163,24 @@ function AdminWorkspaceEdit() {
           </ImageInputContainer>
         </ImageContainer>
         <DescriptionContainer>
-          <NewAppTextarea label="주점 설명" ref={descriptionRef} defaultValue={workspace?.description || ''} width="100%" />
+          <NewAppTextarea
+            label="주점 설명"
+            ref={descriptionRef}
+            defaultValue={workspace?.description || ''}
+            placeholder={`최대 ${WORKSPACE_DESCRIPTION_MAX_LENGTH}자까지 가능합니다.`}
+            maxLength={WORKSPACE_DESCRIPTION_MAX_LENGTH}
+            width="100%"
+          />
         </DescriptionContainer>
         <NoticeContainer>
-          <NewAppTextarea label="공지 사항" ref={noticeRef} defaultValue={workspace?.notice || ''} width="100%" />
+          <NewAppTextarea
+            label="공지 사항"
+            ref={noticeRef}
+            defaultValue={workspace?.notice || ''}
+            placeholder={`최대 ${WORKSPACE_NOTICE_MAX_LENGTH}자까지 가능합니다.`}
+            maxLength={WORKSPACE_NOTICE_MAX_LENGTH}
+            width="100%"
+          />
         </NoticeContainer>
         <ButtonContainer>
           <NewCommonButton size={'sm'} onClick={handleSubmit}>

--- a/src/utils/validateWorkspaceInfoForm.ts
+++ b/src/utils/validateWorkspaceInfoForm.ts
@@ -1,0 +1,36 @@
+import { match } from 'ts-pattern';
+
+interface WorkspaceInfoValidationResult {
+  name: string;
+  description: string;
+  notice: string;
+  errorMessage: string | null;
+}
+
+export const WORKSPACE_NAME_MAX_LENGTH = 50;
+export const WORKSPACE_DESCRIPTION_MAX_LENGTH = 200;
+export const WORKSPACE_NOTICE_MAX_LENGTH = 500;
+
+function normalizeInput(value: string | undefined) {
+  return value?.trim() ?? '';
+}
+
+export function validateWorkspaceInfoForm(
+  rawName: string | undefined,
+  rawDescription: string | undefined,
+  rawNotice: string | undefined,
+): WorkspaceInfoValidationResult {
+  const name = normalizeInput(rawName);
+  const description = normalizeInput(rawDescription);
+  const notice = normalizeInput(rawNotice);
+
+  return {
+    name,
+    description,
+    notice,
+    errorMessage: match({ name, description })
+      .with({ name: '' }, () => '주점명을 입력해주세요.')
+      .with({ description: '' }, () => '주점 설명을 입력해주세요.')
+      .otherwise(() => null),
+  };
+}

--- a/src/utils/validateWorkspaceInfoForm.ts
+++ b/src/utils/validateWorkspaceInfoForm.ts
@@ -7,9 +7,9 @@ interface WorkspaceInfoValidationResult {
   errorMessage: string | null;
 }
 
-export const WORKSPACE_NAME_MAX_LENGTH = 50;
-export const WORKSPACE_DESCRIPTION_MAX_LENGTH = 200;
-export const WORKSPACE_NOTICE_MAX_LENGTH = 500;
+export const WORKSPACE_NAME_MAX_LENGTH = 30;
+export const WORKSPACE_DESCRIPTION_MAX_LENGTH = 100;
+export const WORKSPACE_NOTICE_MAX_LENGTH = 300;
 
 function normalizeInput(value: string | undefined) {
   return value?.trim() ?? '';


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

주점 정보 관리 화면에 validation logic을 추가했습니다.

<img width="2861" height="1576" alt="image" src="https://github.com/user-attachments/assets/c61d0d2c-fe73-4594-a81c-90d0d87f7e0e" />

- 주점명: 최대 50자 입력 제한, 저장 시 공백 trim, 빈 값 저장 방지
- 주점 설명: 최대 200자 입력 제한, 저장 시 공백 trim, 빈 값 저장 방지
- 공지 사항: 최대 500자 입력 제한, 저장 시 공백 trim
- 워크스페이스 정보 검증 로직을 `validateWorkspaceInfoForm` 유틸로 분리해 재사용 가능하게 정리

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- `src/pages/admin/AdminWorkspaceEdit.tsx`
  - 저장 시 ref 값 그대로 넘기지 않고, 검증 유틸에서 정리된 값을 사용하도록 변경했습니다.
  - 입력 길이 제한은 `maxLength`로 UI 단계에서 막고, 제출 시에는 필수값 검증만 수행합니다.

- `src/utils/validateWorkspaceInfoForm.ts`
  - 주점명/설명/공지사항의 trim 처리와 필수값 검증을 담당합니다.
  - 값 기반 분기는 `ts-pattern`의 `match`를 사용했습니다.
