### PR TITLE
REFACTOR - SEO 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,9 @@
   <head>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@kfonts/line-seed-sans-kr@0.1.0/index.min.css">
     <meta charset="utf-8" />
-    <meta property="og:url" content="https://kio-school.com" />
-    <meta property="og:title" content="키오스쿨" />
-    <meta property="og:description" content="대학 주점 테이블 오더 서비스, 키오스쿨입니다!" />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://kio-school.com/preview.png" />
-    <meta property="og:site_name" content="키오스쿨" />
     <meta name="naver-site-verification" content="1af88f1f8485f61824dd14cbf4759c9ce29d713d" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="대학 주점 테이블 오더 서비스, 키오스쿨입니다!" />
     <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^7.2.0",
@@ -44,6 +45,7 @@
     "react-datepicker": "^6.1.0",
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
+    "react-helmet-async": "^3.0.0",
     "react-paginate": "^8.2.0",
     "react-router-dom": "^6.20.1",
     "react-scroll": "npm:@kioschool/react-scroll",
@@ -56,7 +58,7 @@
   },
   "scripts": {
     "start": "vite --host",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/generate-sitemap.mjs",
     "build:dev": "tsc -b && vite build --mode dev",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
@@ -94,6 +96,7 @@
     "storybook": "^8.6.17",
     "typescript": "^5.9.3",
     "vite": "7.3.2",
+    "vite-prerender-plugin": "^0.5.13",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://kio-school.com/sitemap.xml

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SITE_URL = 'https://kio-school.com';
+const OUTPUT_PATH = path.resolve(process.cwd(), 'build', 'sitemap.xml');
+const ROUTES = ['/', '/info'];
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${ROUTES.map((route) => `  <url><loc>${SITE_URL}${route === '/' ? '' : route}</loc></url>`).join('\n')}
+</urlset>
+`;
+
+fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+fs.writeFileSync(OUTPUT_PATH, sitemap, 'utf8');

--- a/src/components/common/page/PageSeo.tsx
+++ b/src/components/common/page/PageSeo.tsx
@@ -1,0 +1,31 @@
+import { Helmet } from 'react-helmet-async';
+import type { MarketingSeoConfigEntry } from '@constants/marketingSeo';
+
+function PageSeo({ title, description, canonicalUrl, ogImageUrl, structuredData }: MarketingSeoConfigEntry) {
+  return (
+    <Helmet prioritizeSeoTags={true}>
+      <html lang="ko" />
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta name="robots" content="index, follow" />
+      <link rel="canonical" href={canonicalUrl} />
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="키오스쿨" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:image" content={ogImageUrl} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={ogImageUrl} />
+      {structuredData.map((item) => (
+        <script key={JSON.stringify(item)} type="application/ld+json">
+          {JSON.stringify(item)}
+        </script>
+      ))}
+    </Helmet>
+  );
+}
+
+export default PageSeo;

--- a/src/components/user/AuthenticationButton.tsx
+++ b/src/components/user/AuthenticationButton.tsx
@@ -1,13 +1,13 @@
-import useAuthentication from '@hooks/useAuthentication';
+import useMarketingLoginStatus from '@hooks/useMarketingLoginStatus';
 import { NavLinkItem } from '@components/common/nav/NavBar';
 import { ADMIN_ROUTES, USER_ROUTES } from '@constants/routes';
 
 function AuthenticationButton() {
-  const { isLoggedIn } = useAuthentication();
+  const isLoggedIn = useMarketingLoginStatus();
 
   return (
     <>
-      {isLoggedIn() ? (
+      {isLoggedIn ? (
         <NavLinkItem to={ADMIN_ROUTES.HOME} className={'nav-link-item'}>
           내 주점
         </NavLinkItem>

--- a/src/components/user/home/CtaSection.tsx
+++ b/src/components/user/home/CtaSection.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import Typewriter from 'typewriter-effect';
 import { motion, useInView } from 'framer-motion';
@@ -8,7 +8,7 @@ import { colFlex, rowFlex } from '@styles/flexStyles';
 import { mobileMediaQuery } from '@styles/globalStyles';
 import { captionTypography, headingTypography, subheadingTypography } from '@styles/landingTypography';
 import { ADMIN_ROUTES, USER_ROUTES } from '@constants/routes';
-import useAuthentication from '@hooks/useAuthentication';
+import useMarketingLoginStatus from '@hooks/useMarketingLoginStatus';
 import useMouseGlow, { MouseGlow } from './useMouseGlow';
 
 const Container = styled.div`
@@ -136,12 +136,19 @@ const Reassurance = styled.p`
 `;
 
 function CtaSection() {
-  const { isLoggedIn } = useAuthentication();
+  const isLoggedIn = useMarketingLoginStatus();
   const containerRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLDivElement>(null);
   const kioRef = useRef<HTMLDivElement>(null);
+  const [hasMounted, setHasMounted] = useState(false);
   const isInViewport = useInView(titleRef, { once: true, amount: 0.3 });
   const { mousePos, isHovering, intensity, handleMouseMove, handleMouseEnter, handleMouseLeave } = useMouseGlow(containerRef, kioRef);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  const isTypewriterVisible = hasMounted && isInViewport;
 
   return (
     <Container ref={containerRef} onMouseMove={handleMouseMove} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
@@ -158,7 +165,7 @@ function CtaSection() {
             이번 축제,
             <br />
             <TypewriterLine ref={kioRef} style={{ '--kio-shadow': `0 0 ${28 * intensity}px rgba(255, 145, 66, ${0.6 * intensity})` } as React.CSSProperties}>
-              {isInViewport && (
+              {isTypewriterVisible ? (
                 <Typewriter
                   onInit={(typewriter) => {
                     typewriter
@@ -173,6 +180,8 @@ function CtaSection() {
                   }}
                   options={{ delay: 100, cursor: '|' }}
                 />
+              ) : (
+                '키오스쿨'
               )}
             </TypewriterLine>
             과 함께하세요
@@ -193,7 +202,7 @@ function CtaSection() {
           transition={{ duration: 0.4, ease: 'easeOut', delay: 0.2 }}
         >
           <CtaRow>
-            <CtaButton to={ADMIN_ROUTES.HOME}>{isLoggedIn() ? '어드민 홈으로' : '무료로 시작하기'}</CtaButton>
+            <CtaButton to={ADMIN_ROUTES.HOME}>{isLoggedIn ? '어드민 홈으로' : '무료로 시작하기'}</CtaButton>
             <SecondaryButton to={USER_ROUTES.INFO}>서비스 알아보기</SecondaryButton>
           </CtaRow>
           <Reassurance>별도 비용 없이 시작할 수 있어요</Reassurance>

--- a/src/components/user/home/hero/HeroSection.tsx
+++ b/src/components/user/home/hero/HeroSection.tsx
@@ -166,14 +166,13 @@ function HeroSection() {
 
       <ContentWrapper initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.4, ease: 'easeOut' }}>
         <MainCopy>
-          대학 축제 주점을 위한
-          <MobileOnlyBreak />
-          <OrangeText> QR 주문 서비스</OrangeText>
+          축제는 <OrangeText>즐기라고</OrangeText>
+          <MobileOnlyBreak /> 있는 거니까
         </MainCopy>
         <SubCopy>
-          축제는 즐기라고 있는 거니까.
+          QR 주문, 실시간 주문 관리, 자동 정산까지
           <br />
-          QR 주문, 실시간 주문 관리, 자동 정산까지 주점 운영의 모든 것을{' '}
+          주점 운영의 모든 것을{' '}
           <KioHighlight
             ref={kioRef}
             style={

--- a/src/components/user/home/hero/HeroSection.tsx
+++ b/src/components/user/home/hero/HeroSection.tsx
@@ -7,7 +7,7 @@ import { mobileMediaQuery } from '@styles/globalStyles';
 import { displayHeadingTypography, subheadingTypography } from '@styles/landingTypography';
 import { Color } from '@resources/colors';
 import { ADMIN_ROUTES, USER_ROUTES } from '@constants/routes';
-import useAuthentication from '@hooks/useAuthentication';
+import useMarketingLoginStatus from '@hooks/useMarketingLoginStatus';
 import useMouseGlow, { MouseGlow } from '@components/user/home/useMouseGlow';
 import cloud1 from '@resources/image/home/cloud1.png';
 import cloud2 from '@resources/image/home/cloud2.png';
@@ -146,7 +146,7 @@ function lerpRgb(a: [number, number, number], b: [number, number, number], t: nu
 }
 
 function HeroSection() {
-  const { isLoggedIn } = useAuthentication();
+  const isLoggedIn = useMarketingLoginStatus();
   const containerRef = useRef<HTMLDivElement>(null);
   const kioRef = useRef<HTMLSpanElement>(null);
   const { mousePos, isHovering, intensity, handleMouseMove, handleMouseEnter, handleMouseLeave } = useMouseGlow(containerRef, kioRef);
@@ -166,13 +166,14 @@ function HeroSection() {
 
       <ContentWrapper initial={{ opacity: 0, scale: 0.98 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.4, ease: 'easeOut' }}>
         <MainCopy>
-          축제는 <OrangeText>즐기라고</OrangeText>
-          <MobileOnlyBreak /> 있는 거니까
+          대학 축제 주점을 위한
+          <MobileOnlyBreak />
+          <OrangeText> QR 주문 서비스</OrangeText>
         </MainCopy>
         <SubCopy>
-          QR 주문, 실시간 주문 관리, 자동 정산까지
+          축제는 즐기라고 있는 거니까.
           <br />
-          주점 운영의 모든 것을{' '}
+          QR 주문, 실시간 주문 관리, 자동 정산까지 주점 운영의 모든 것을{' '}
           <KioHighlight
             ref={kioRef}
             style={
@@ -187,7 +188,7 @@ function HeroSection() {
           이 대신할게요
         </SubCopy>
         <CtaRow>
-          <CtaButton to={ADMIN_ROUTES.HOME}>{isLoggedIn() ? '어드민 홈으로' : '무료로 시작하기'}</CtaButton>
+          <CtaButton to={ADMIN_ROUTES.HOME}>{isLoggedIn ? '어드민 홈으로' : '무료로 시작하기'}</CtaButton>
           <SecondaryButton to={USER_ROUTES.INFO}>서비스 알아보기</SecondaryButton>
         </CtaRow>
       </ContentWrapper>

--- a/src/components/user/info/InfoCtaSection.tsx
+++ b/src/components/user/info/InfoCtaSection.tsx
@@ -7,7 +7,7 @@ import { mobileMediaQuery } from '@styles/globalStyles';
 import { captionTypography, headingTypography, subheadingTypography } from '@styles/landingTypography';
 import { Color } from '@resources/colors';
 import { ADMIN_ROUTES } from '@constants/routes';
-import useAuthentication from '@hooks/useAuthentication';
+import useMarketingLoginStatus from '@hooks/useMarketingLoginStatus';
 
 const Container = styled.div`
   width: 100%;
@@ -90,7 +90,7 @@ const ContactLink = styled.a`
 `;
 
 function InfoCtaSection() {
-  const { isLoggedIn } = useAuthentication();
+  const isLoggedIn = useMarketingLoginStatus();
 
   return (
     <Container>
@@ -103,7 +103,7 @@ function InfoCtaSection() {
         <CtaDivider />
         <Title>이번 축제, 키오스쿨과 함께하세요</Title>
         <Subtitle>가입부터 주점 운영까지, 3분이면 준비 끝</Subtitle>
-        <CtaButton to={ADMIN_ROUTES.HOME}>{isLoggedIn() ? '어드민 홈으로' : '무료로 시작하기'}</CtaButton>
+        <CtaButton to={ADMIN_ROUTES.HOME}>{isLoggedIn ? '어드민 홈으로' : '무료로 시작하기'}</CtaButton>
         <Reassurance>별도 비용 없이 시작할 수 있어요</Reassurance>
         <ContactLink href="https://www.instagram.com/kioschool/" target="_blank" rel="noopener noreferrer">
           <RiInstagramLine size={16} />

--- a/src/components/user/info/InfoFaqSection.tsx
+++ b/src/components/user/info/InfoFaqSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import styled from '@emotion/styled';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { colFlex } from '@styles/flexStyles';
 import { mobileMediaQuery } from '@styles/globalStyles';
 import { bodyTypography, eyebrowTypography, headingTypography } from '@styles/landingTypography';
@@ -68,8 +68,11 @@ const Chevron = styled.span<{ open: boolean }>`
 `;
 
 const AnswerText = styled(motion.div)`
-  padding-bottom: 24px;
   overflow: hidden;
+`;
+
+const AnswerInner = styled.div`
+  padding-bottom: 24px;
   ${bodyTypography};
 `;
 
@@ -102,22 +105,18 @@ function FaqAccordionItem({ question, answer }: { question: string; answer: stri
 
   return (
     <FaqItem>
-      <FaqQuestion onClick={() => setIsOpen(!isOpen)}>
+      <FaqQuestion onClick={() => setIsOpen(!isOpen)} aria-expanded={isOpen} type="button">
         <QuestionText>{question}</QuestionText>
         <Chevron open={isOpen}>&#8964;</Chevron>
       </FaqQuestion>
-      <AnimatePresence>
-        {isOpen && (
-          <AnswerText
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2, ease: 'easeOut' }}
-          >
-            {answer}
-          </AnswerText>
-        )}
-      </AnimatePresence>
+      <AnswerText
+        initial={false}
+        animate={{ height: isOpen ? 'auto' : 0, opacity: isOpen ? 1 : 0 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+        aria-hidden={!isOpen}
+      >
+        <AnswerInner>{answer}</AnswerInner>
+      </AnswerText>
     </FaqItem>
   );
 }

--- a/src/components/user/info/InfoFeaturesSection.tsx
+++ b/src/components/user/info/InfoFeaturesSection.tsx
@@ -135,8 +135,8 @@ function InfoFeaturesSection() {
         style={{ textAlign: 'center' }}
       >
         <SectionLabel>FEATURES</SectionLabel>
-        <SectionTitle>키오스쿨이 제공하는 기능</SectionTitle>
-        <SectionSubtitle>주점 운영에 필요한 것만, 군더더기 없이</SectionSubtitle>
+        <SectionTitle>대학 축제 주점 운영에 필요한 핵심 기능</SectionTitle>
+        <SectionSubtitle>QR 주문부터 주문 관리, 자동 정산, 테이블 운영까지 한 번에 준비하세요</SectionSubtitle>
       </motion.div>
       <FeatureList>
         {FEATURES.map((feature, index) => (

--- a/src/components/user/info/InfoHeroSection.tsx
+++ b/src/components/user/info/InfoHeroSection.tsx
@@ -1,0 +1,180 @@
+import styled from '@emotion/styled';
+import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
+import { colFlex, rowFlex } from '@styles/flexStyles';
+import { mobileMediaQuery } from '@styles/globalStyles';
+import { captionTypography, displayHeadingTypography, subheadingTypography } from '@styles/landingTypography';
+import { URLS } from '@constants/urls';
+import { ADMIN_ROUTES } from '@constants/routes';
+import { Color } from '@resources/colors';
+import useMarketingLoginStatus from '@hooks/useMarketingLoginStatus';
+
+const Container = styled.div`
+  width: 100%;
+  padding: 140px 24px 120px;
+  box-sizing: border-box;
+  background: radial-gradient(circle at top, rgba(255, 145, 66, 0.08) 0%, rgba(255, 145, 66, 0.02) 28%, ${Color.WHITE} 70%);
+  ${colFlex({ align: 'center' })};
+
+  ${mobileMediaQuery} {
+    padding: 120px 20px 80px;
+  }
+`;
+
+const ContentWrapper = styled(motion.div)`
+  max-width: 960px;
+  width: 100%;
+  ${colFlex({ align: 'center' })};
+`;
+
+const Eyebrow = styled.span`
+  font-size: 13px;
+  font-weight: 700;
+  color: ${Color.KIO_ORANGE};
+  letter-spacing: 0.08em;
+`;
+
+const Title = styled.h1`
+  margin-top: 16px;
+  text-align: center;
+  ${displayHeadingTypography};
+`;
+
+const Accent = styled.span`
+  color: ${Color.KIO_ORANGE};
+`;
+
+const Description = styled.p`
+  max-width: 760px;
+  margin-top: 24px;
+  text-align: center;
+  white-space: pre-line;
+  ${subheadingTypography};
+`;
+
+const FeatureList = styled.div`
+  margin-top: 36px;
+  gap: 12px;
+  flex-wrap: wrap;
+  ${rowFlex({ justify: 'center', align: 'center' })};
+
+  ${mobileMediaQuery} {
+    gap: 10px;
+  }
+`;
+
+const FeatureBadge = styled.span`
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(255, 145, 66, 0.1);
+  color: #3c3530;
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+const CtaRow = styled.div`
+  margin-top: 40px;
+  gap: 12px;
+  ${rowFlex({ justify: 'center', align: 'center' })};
+
+  ${mobileMediaQuery} {
+    gap: 8px;
+    flex-wrap: wrap;
+    ${rowFlex({ justify: 'center', align: 'center' })};
+  }
+`;
+
+const PrimaryButton = styled(Link)`
+  padding: 18px 48px;
+  background: ${Color.KIO_ORANGE};
+  color: ${Color.WHITE};
+  border-radius: 999px;
+  font-size: 18px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: #ffa562;
+  }
+
+  &:active {
+    background: #e87d30;
+    transition: 0ms;
+  }
+
+  ${mobileMediaQuery} {
+    padding: 14px 20px;
+    font-size: 14px;
+  }
+`;
+
+const SecondaryButton = styled.a`
+  padding: 18px 48px;
+  background: transparent;
+  color: #6b7684;
+  border: 1px solid #e5e8eb;
+  border-radius: 999px;
+  font-size: 18px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: #f8f9fa;
+  }
+
+  &:active {
+    background: #f2f4f6;
+    transition: 0ms;
+  }
+
+  ${mobileMediaQuery} {
+    padding: 14px 20px;
+    font-size: 14px;
+  }
+`;
+
+const Reassurance = styled.p`
+  margin-top: 16px;
+  text-align: center;
+  ${captionTypography};
+`;
+
+const CORE_FEATURES = ['QR 주문', '실시간 주문 관리', '자동 정산', '테이블 관리'];
+
+function InfoHeroSection() {
+  const isLoggedIn = useMarketingLoginStatus();
+
+  return (
+    <Container>
+      <ContentWrapper initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, ease: 'easeOut' }}>
+        <Eyebrow>ABOUT KIOSCHOOL</Eyebrow>
+        <Title>
+          대학 축제 주점 운영을 위한
+          <br />
+          <Accent>QR 주문 서비스</Accent>
+        </Title>
+        <Description>
+          키오스쿨은 대학 축제 주점 운영에 맞춰 설계된 QR 주문 서비스입니다.
+          {'\n'}
+          손님은 테이블에서 바로 주문하고, 운영팀은 실시간으로 주문을 확인하며, 축제 종료 후에는 정산까지 빠르게 마무리할 수 있습니다.
+        </Description>
+        <FeatureList>
+          {CORE_FEATURES.map((feature) => (
+            <FeatureBadge key={feature}>{feature}</FeatureBadge>
+          ))}
+        </FeatureList>
+        <CtaRow>
+          <PrimaryButton to={ADMIN_ROUTES.HOME}>{isLoggedIn ? '어드민 홈으로' : '무료로 시작하기'}</PrimaryButton>
+          <SecondaryButton href={URLS.EXTERNAL.INSTAGRAM} target="_blank" rel="noopener noreferrer">
+            문의하기
+          </SecondaryButton>
+        </CtaRow>
+        <Reassurance>별도 장비 없이 바로 도입할 수 있어요</Reassurance>
+      </ContentWrapper>
+    </Container>
+  );
+}
+
+export default InfoHeroSection;

--- a/src/constants/marketingSeo.ts
+++ b/src/constants/marketingSeo.ts
@@ -1,0 +1,149 @@
+import { URLS } from '@constants/urls';
+
+interface MarketingOrganizationSchema {
+  '@context': 'https://schema.org';
+  '@type': 'Organization';
+  name: string;
+  url: string;
+  logo: string;
+  sameAs: string[];
+  description: string;
+}
+
+interface MarketingWebsiteSchema {
+  '@context': 'https://schema.org';
+  '@type': 'WebSite';
+  name: string;
+  url: string;
+  description: string;
+  inLanguage: string;
+}
+
+interface MarketingServiceSchema {
+  '@context': 'https://schema.org';
+  '@type': 'Service';
+  name: string;
+  serviceType: string;
+  provider: {
+    '@type': 'Organization';
+    name: string;
+  };
+  areaServed: string;
+  audience: {
+    '@type': 'Audience';
+    audienceType: string;
+  };
+  description: string;
+  url: string;
+}
+
+interface MarketingHeadElement {
+  type: string;
+  props: Record<string, string>;
+  children?: string;
+}
+
+export interface MarketingSeoConfigEntry {
+  title: string;
+  description: string;
+  canonicalUrl: string;
+  ogImageUrl: string;
+  structuredData: object[];
+}
+
+const MARKETING_OG_IMAGE_URL = `${URLS.EXTERNAL.KIO_SCHOOL}/preview.png`;
+
+const ORGANIZATION_SCHEMA: MarketingOrganizationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: '키오스쿨',
+  url: URLS.EXTERNAL.KIO_SCHOOL,
+  logo: `${URLS.EXTERNAL.KIO_SCHOOL}/logo192.png`,
+  sameAs: [URLS.EXTERNAL.INSTAGRAM, URLS.EXTERNAL.YOUTUBE],
+  description: '대학 축제 주점을 위한 QR 주문, 실시간 주문 관리, 자동 정산 서비스',
+};
+
+const WEBSITE_SCHEMA: MarketingWebsiteSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: '키오스쿨',
+  url: URLS.EXTERNAL.KIO_SCHOOL,
+  description: '대학 축제 주점을 위한 QR 주문 서비스 키오스쿨',
+  inLanguage: 'ko-KR',
+};
+
+const SERVICE_SCHEMA: MarketingServiceSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: '키오스쿨',
+  serviceType: '대학 축제 주점 QR 주문 서비스',
+  provider: {
+    '@type': 'Organization',
+    name: '키오스쿨',
+  },
+  areaServed: 'KR',
+  audience: {
+    '@type': 'Audience',
+    audienceType: '대학 축제 주점 운영자 및 학생회',
+  },
+  description: '대학 축제 주점을 위한 QR 주문, 실시간 주문 관리, 자동 정산, 테이블 관리 서비스',
+  url: `${URLS.EXTERNAL.KIO_SCHOOL}/info`,
+};
+
+export type MarketingSeoKey = 'home' | 'info';
+
+type MarketingSeoConfig = Record<MarketingSeoKey, MarketingSeoConfigEntry>;
+
+export const MARKETING_SEO: MarketingSeoConfig = {
+  home: {
+    title: '키오스쿨 | 대학 축제 주점 QR 주문·실시간 주문 관리 서비스',
+    description: '대학 축제 주점을 위한 QR 주문 서비스 키오스쿨. 테이블 주문, 실시간 주문 관리, 자동 정산까지 한 번에 운영하세요.',
+    canonicalUrl: URLS.EXTERNAL.KIO_SCHOOL,
+    ogImageUrl: MARKETING_OG_IMAGE_URL,
+    structuredData: [WEBSITE_SCHEMA, ORGANIZATION_SCHEMA],
+  },
+  info: {
+    title: '키오스쿨 소개 | 대학 축제 주점 운영을 위한 QR 주문 서비스',
+    description: '키오스쿨의 QR 주문, 실시간 주문 관리, 자동 정산, 테이블 관리 기능을 확인하세요. 대학 축제 주점 운영을 더 쉽고 안정적으로 바꿉니다.',
+    canonicalUrl: `${URLS.EXTERNAL.KIO_SCHOOL}/info`,
+    ogImageUrl: MARKETING_OG_IMAGE_URL,
+    structuredData: [ORGANIZATION_SCHEMA, SERVICE_SCHEMA],
+  },
+};
+
+export function getMarketingSeoKeyByPathname(pathname: string): MarketingSeoKey {
+  return pathname === '/info' ? 'info' : 'home';
+}
+
+export function getMarketingSeoByPathname(pathname: string): MarketingSeoConfigEntry {
+  return MARKETING_SEO[getMarketingSeoKeyByPathname(pathname)];
+}
+
+export function getMarketingHeadElements(pathname: string): Set<MarketingHeadElement> {
+  const seo = getMarketingSeoByPathname(pathname);
+  const headElements: MarketingHeadElement[] = [
+    { type: 'meta', props: { name: 'description', content: seo.description } },
+    { type: 'meta', props: { name: 'robots', content: 'index, follow' } },
+    { type: 'link', props: { rel: 'canonical', href: seo.canonicalUrl } },
+    { type: 'meta', props: { property: 'og:type', content: 'website' } },
+    { type: 'meta', props: { property: 'og:site_name', content: '키오스쿨' } },
+    { type: 'meta', props: { property: 'og:title', content: seo.title } },
+    { type: 'meta', props: { property: 'og:description', content: seo.description } },
+    { type: 'meta', props: { property: 'og:url', content: seo.canonicalUrl } },
+    { type: 'meta', props: { property: 'og:image', content: seo.ogImageUrl } },
+    { type: 'meta', props: { name: 'twitter:card', content: 'summary_large_image' } },
+    { type: 'meta', props: { name: 'twitter:title', content: seo.title } },
+    { type: 'meta', props: { name: 'twitter:description', content: seo.description } },
+    { type: 'meta', props: { name: 'twitter:image', content: seo.ogImageUrl } },
+  ];
+
+  seo.structuredData.forEach((item) => {
+    headElements.push({
+      type: 'script',
+      props: { type: 'application/ld+json' },
+      children: JSON.stringify(item),
+    });
+  });
+
+  return new Set(headElements);
+}

--- a/src/hooks/useAuthentication.tsx
+++ b/src/hooks/useAuthentication.tsx
@@ -7,6 +7,7 @@ function useAuthentication() {
   const navigate = useNavigate();
 
   const isLoggedIn = () => {
+    if (typeof window === 'undefined') return false;
     return localStorage.getItem('isLoggedIn') === 'true';
   };
 

--- a/src/hooks/useMarketingLoginStatus.tsx
+++ b/src/hooks/useMarketingLoginStatus.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+function useMarketingLoginStatus() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    setIsLoggedIn(localStorage.getItem('isLoggedIn') === 'true');
+  }, []);
+
+  return isLoggedIn;
+}
+
+export default useMarketingLoginStatus;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, createRoutesFromChildren, matchRoutes, Routes, useLocati
 import { CookiesProvider } from 'react-cookie';
 import * as Sentry from '@sentry/react';
 import React from 'react';
+import { HelmetProvider } from 'react-helmet-async';
 import SentryErrorFallback from './components/common/fallback/SentryErrorFallback';
 import { URLS } from '@constants/urls';
 import type { SentryEnvironment } from '@constants/sentry';
@@ -57,10 +58,12 @@ export const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <Sentry.ErrorBoundary fallback={() => <SentryErrorFallback />}>
-    <BrowserRouter>
-      <CookiesProvider>
-        <App />
-      </CookiesProvider>
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <CookiesProvider>
+          <App />
+        </CookiesProvider>
+      </BrowserRouter>
+    </HelmetProvider>
   </Sentry.ErrorBoundary>,
 );

--- a/src/pages/user/home/Home.tsx
+++ b/src/pages/user/home/Home.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
+import PageSeo from '@components/common/page/PageSeo';
 import { MotionConfig } from 'framer-motion';
 import AppContainer from '@components/common/container/AppContainer';
 import { colFlex } from '@styles/flexStyles';
+import { MARKETING_SEO } from '@constants/marketingSeo';
 import HeroSection from '@components/user/home/hero/HeroSection';
 import PainPointSection from '@components/user/home/PainPointSection';
 import HowItWorksSection from '@components/user/home/how-it-works/HowItWorksSection';
@@ -24,6 +26,7 @@ function Home() {
   return (
     <MotionConfig reducedMotion="user">
       <LandingWrapper>
+        <PageSeo {...MARKETING_SEO.home} />
         <AppContainer useFlex={colFlex()} customWidth={'100%'} useTitle={false} useFullHeight={true}>
           <>
             <HeroSection />

--- a/src/pages/user/info/Info.tsx
+++ b/src/pages/user/info/Info.tsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled';
+import PageSeo from '@components/common/page/PageSeo';
 import { MotionConfig } from 'framer-motion';
 import AppContainer from '@components/common/container/AppContainer';
 import { colFlex } from '@styles/flexStyles';
+import { MARKETING_SEO } from '@constants/marketingSeo';
+import InfoHeroSection from '@components/user/info/InfoHeroSection';
 import InfoFeaturesSection from '@components/user/info/InfoFeaturesSection';
 import InfoHowToUseSection from '@components/user/info/InfoHowToUseSection';
 import InfoCaseStudiesSection from '@components/user/info/InfoCaseStudiesSection';
@@ -25,8 +28,10 @@ function Info() {
   return (
     <MotionConfig reducedMotion="user">
       <LandingWrapper>
+        <PageSeo {...MARKETING_SEO.info} />
         <AppContainer useFlex={colFlex()} customWidth={'100%'} useTitle={false} useFullHeight={true}>
           <>
+            <InfoHeroSection />
             <InfoFeaturesSection />
             <InfoHowToUseSection />
             <InfoCaseStudiesSection />

--- a/src/prerender.tsx
+++ b/src/prerender.tsx
@@ -1,0 +1,132 @@
+import createCache from '@emotion/cache';
+import { CacheProvider } from '@emotion/react';
+import { renderToString } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom/server';
+import { Route, Routes } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+import type { PrerenderArguments, PrerenderResult } from 'vite-prerender-plugin';
+import Home from '@pages/user/home/Home';
+import Info from '@pages/user/info/Info';
+import { getMarketingHeadElements, getMarketingSeoByPathname } from '@constants/marketingSeo';
+
+interface FakeNode {
+  parentNode: FakeElement | null;
+}
+
+interface FakeStyleSheet {
+  cssRules: string[];
+  insertRule: (rule: string, index: number) => void;
+}
+
+interface FakeElement extends FakeNode {
+  children: FakeNode[];
+  firstChild: FakeNode | null;
+  nextSibling: FakeNode | null;
+  sheet?: FakeStyleSheet;
+  setAttribute: (_name: string, _value: string) => void;
+  appendChild: (node: FakeNode) => FakeNode;
+  insertBefore: (node: FakeNode, _before?: FakeNode | null) => FakeNode;
+  removeChild: (node: FakeNode) => FakeNode;
+}
+
+interface FakeDocument {
+  head: FakeElement;
+  styleSheets: Array<{ ownerNode: FakeElement } & FakeStyleSheet>;
+  querySelectorAll: (_selector: string) => FakeElement[];
+  createElement: (tagName: string) => FakeElement;
+  createTextNode: (text: string) => FakeNode & { textContent: string };
+}
+
+function createFakeElement(styleSheets: FakeDocument['styleSheets'], tagName: string): FakeElement {
+  const element: FakeElement = {
+    children: [],
+    firstChild: null,
+    nextSibling: null,
+    parentNode: null,
+    setAttribute: () => undefined,
+    appendChild(node) {
+      node.parentNode = element;
+      element.children.push(node);
+      element.firstChild = element.children[0] ?? null;
+      return node;
+    },
+    insertBefore(node) {
+      node.parentNode = element;
+      element.children.push(node);
+      element.firstChild = element.children[0] ?? null;
+      return node;
+    },
+    removeChild(node) {
+      element.children = element.children.filter((child) => child !== node);
+      element.firstChild = element.children[0] ?? null;
+      return node;
+    },
+  };
+
+  if (tagName === 'style') {
+    const sheet: FakeStyleSheet = {
+      cssRules: [],
+      insertRule(rule) {
+        sheet.cssRules.push(rule);
+      },
+    };
+    element.sheet = sheet;
+    styleSheets.push({ ownerNode: element, ...sheet });
+  }
+
+  return element;
+}
+
+function ensurePrerenderDocument() {
+  if (typeof document !== 'undefined') return;
+
+  const styleSheets: FakeDocument['styleSheets'] = [];
+  const head = createFakeElement(styleSheets, 'head');
+  const fakeDocument: FakeDocument = {
+    head,
+    styleSheets,
+    querySelectorAll: () => [],
+    createElement: (tagName) => createFakeElement(styleSheets, tagName),
+    createTextNode: (text) => ({
+      parentNode: null,
+      textContent: text,
+    }),
+  };
+
+  Object.defineProperty(globalThis, 'document', {
+    value: fakeDocument,
+    configurable: true,
+  });
+}
+
+function getPathname(url: string) {
+  return new URL(url, 'https://kio-school.com').pathname;
+}
+
+export async function prerender({ url }: PrerenderArguments): Promise<PrerenderResult> {
+  ensurePrerenderDocument();
+  const pathname = getPathname(url);
+  const seo = getMarketingSeoByPathname(pathname);
+  const cache = createCache({ key: 'css' });
+  const html = renderToString(
+    <CacheProvider value={cache}>
+      <HelmetProvider>
+        <StaticRouter location={pathname}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/info" element={<Info />} />
+          </Routes>
+        </StaticRouter>
+      </HelmetProvider>
+    </CacheProvider>,
+  );
+
+  return {
+    html,
+    head: {
+      lang: 'ko',
+      title: seo.title,
+      elements: getMarketingHeadElements(pathname),
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,20 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 /* eslint-disable import/no-extraneous-dependencies */
+import * as path from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { vitePrerenderPlugin } from 'vite-prerender-plugin';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [
     react(),
     tsconfigPaths(),
+    ...vitePrerenderPlugin({
+      renderTarget: '#root',
+      prerenderScript: path.resolve(__dirname, 'src/prerender.tsx'),
+      additionalPrerenderRoutes: ['/info'],
+    }),
     sentryVitePlugin({
       org: 'kioschool',
       project: 'kio-school',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,7 +1012,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
-"@jridgewell/sourcemap-codec@^1.4.15":
+"@jridgewell/sourcemap-codec@^1.4.15", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
@@ -2434,6 +2434,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2712,6 +2717,17 @@ css-color-keywords@^1.0.0:
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
   integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
 
+css-select@^5.1.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.2.2.tgz#01b6e8d163637bb2dd6c982ca4ed65863682786e"
+  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-to-react-native@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
@@ -2720,6 +2736,11 @@ css-to-react-native@3.2.0:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
+
+css-what@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
+  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
 css.escape@^1.5.1:
   version "1.5.1"
@@ -2967,6 +2988,36 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dotenv@^16.3.1:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
@@ -3028,6 +3079,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 environment@^1.0.0:
   version "1.1.0"
@@ -3837,6 +3893,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -3921,6 +3982,13 @@ internal-slot@^1.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
   integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 is-arguments@^1.0.4:
   version "1.2.0"
@@ -4172,6 +4240,11 @@ jsqr@^1.4.0:
   resolved "https://registry.yarnpkg.com/jsqr/-/jsqr-1.4.0.tgz#8efb8d0a7cc6863cb6d95116b9069123ce9eb2d1"
   integrity sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==
 
+kolorist@^1.6.0, kolorist@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/kolorist/-/kolorist-1.8.0.tgz#edddbbbc7894bc13302cdf740af6374d4a04743c"
+  integrity sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -4248,7 +4321,7 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4290,6 +4363,13 @@ magic-string@0.30.8:
   integrity sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
+
+"magic-string@0.x >= 0.26.0":
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 magic-string@^0.27.0:
   version "0.27.0"
@@ -4445,6 +4525,14 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-html-parser@^6.1.12:
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.13.tgz#a1df799b83df5c6743fcd92740ba14682083b7e4"
+  integrity sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
+
 node-releases@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
@@ -4454,6 +4542,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -4845,6 +4940,20 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-fast-compare@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
+react-helmet-async@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-3.0.0.tgz#16f31779ea4e4e01827c071b2f15301d074dd570"
+  integrity sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==
+  dependencies:
+    invariant "^2.2.4"
+    react-fast-compare "^3.2.2"
+    shallowequal "^1.1.0"
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -5202,7 +5311,7 @@ set-function-length@^1.2.2:
     gopd "^1.0.1"
     has-property-descriptors "^1.0.2"
 
-shallowequal@1.1.0:
+shallowequal@1.1.0, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -5232,6 +5341,13 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+simple-code-frame@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/simple-code-frame/-/simple-code-frame-1.3.0.tgz#11dd319656a09445639b9c26a0fcb7102c0de00e"
+  integrity sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==
+  dependencies:
+    kolorist "^1.6.0"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -5275,10 +5391,20 @@ source-map@^0.5.7:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
 
+source-map@^0.7.4:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
+  integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
+
 source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+stack-trace@^1.0.0-pre2:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-1.0.0.tgz#bcdf4c2b89382ee1fdd881345a2d3f3613c3f370"
+  integrity sha512-H6D7134xi6qONvh7ZHKgviXf+rd3vhGBSvebPZCaUkd8zvQ+7PtDw6CljPTe4cXWNf2IKZGNqw6VJXSb9IgBpA==
 
 storybook@^8.6.17:
   version "8.6.17"
@@ -5707,6 +5833,18 @@ victory-vendor@^36.6.8:
     d3-shape "^3.1.0"
     d3-time "^3.0.0"
     d3-timer "^3.0.1"
+
+vite-prerender-plugin@^0.5.13:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/vite-prerender-plugin/-/vite-prerender-plugin-0.5.13.tgz#7409a13b393cc186a7472efb82b67df6e42dabd2"
+  integrity sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==
+  dependencies:
+    kolorist "^1.8.0"
+    magic-string "0.x >= 0.26.0"
+    node-html-parser "^6.1.12"
+    simple-code-frame "^1.3.0"
+    source-map "^0.7.4"
+    stack-trace "^1.0.0-pre2"
 
 vite-tsconfig-paths@^5.1.4:
   version "5.1.4"


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

마케팅 페이지 `/` 와 `/info` 의 SEO를 개선했습니다.

- `react-helmet-async` 기반으로 라우트별 title, description, canonical, OG, Twitter Card, JSON-LD를 추가했습니다.
- 홈 히어로 H1을 검색 의도형 문구로 조정했습니다.
- `/info` 상단에 SEO용 인트로 섹션을 추가하고, FAQ 답변이 초기 DOM에 남도록 변경했습니다.
- `vite-prerender-plugin` 으로 `/` 와 `/info` 를 prerender 하도록 빌드 파이프라인을 추가했습니다.
- build 후 `sitemap.xml` 을 생성하고 `robots.txt` 에 sitemap 경로를 연결했습니다.
- 공개 마케팅 UI에서 로그인 상태를 hydration-safe 하게 읽도록 별도 훅을 추가했습니다.

## 🕐 리뷰 예상 시간

> 20m

## ❗❗ 중요한 변경점(Option)

- `src/prerender.tsx`
  - 마케팅 페이지 전용 prerender 엔트리입니다.
  - Emotion styled 컴포넌트를 Node prerender 환경에서 안전하게 렌더링하기 위해 fake document를 주입하는 우회 로직이 들어가 있습니다.
- `src/constants/marketingSeo.ts`
  - 홈/소개 페이지의 SEO 메타데이터와 JSON-LD 정의가 모여 있습니다.
  - prerender head 생성과 runtime Helmet이 같은 설정을 공유합니다.
- `vite.config.ts`, `scripts/generate-sitemap.mjs`
  - build 시 prerender와 sitemap 생성이 함께 수행되도록 바뀌었습니다.
- `src/hooks/useMarketingLoginStatus.tsx`
  - 서버/첫 hydration 시에는 항상 logged-out 기준으로 렌더링하고, mount 후 localStorage를 읽습니다.
  - 상단 인증 버튼, 홈 CTA, info CTA에 적용했습니다.
