### PR TITLE
REFACTOR - 전체주문조회에 주문 취소 필터 추가

### DIFF
--- a/src/constants/data/adminOrderData.ts
+++ b/src/constants/data/adminOrderData.ts
@@ -1,9 +1,12 @@
 import { OrderStatus } from '@@types/index';
 
+export const DEFAULT_TOTAL_ORDER_STATUSES: OrderStatus[] = [OrderStatus.SERVED, OrderStatus.PAID, OrderStatus.NOT_PAID];
+
 export const TABLE_ORDER_STATUS_OPTIONS: { value: OrderStatus; label: string }[] = [
   { value: OrderStatus.SERVED, label: '서빙 완료' },
   { value: OrderStatus.PAID, label: '결제 완료' },
   { value: OrderStatus.NOT_PAID, label: '주문 완료' },
+  { value: OrderStatus.CANCELLED, label: '주문 취소' },
 ];
 
 export const TABLE_ORDER_SORT_OPTIONS = [

--- a/src/hooks/admin/useAdminFetchOrderBase.tsx
+++ b/src/hooks/admin/useAdminFetchOrderBase.tsx
@@ -4,7 +4,7 @@ import { useAtomValue } from 'jotai';
 import { adminTablesAtom } from '@jotai/admin/atoms';
 import useAdminWorkspace from '@hooks/admin/useAdminWorkspace';
 import { OrderStatus } from '@@types/index';
-import { TABLE_ORDER_SORT_OPTIONS, TABLE_ORDER_STATUS_OPTIONS } from '@constants/data/adminOrderData';
+import { DEFAULT_TOTAL_ORDER_STATUSES, TABLE_ORDER_SORT_OPTIONS, TABLE_ORDER_STATUS_OPTIONS } from '@constants/data/adminOrderData';
 
 export const useAdminFetchOrderBase = (workspaceId: string | undefined) => {
   const { fetchWorkspaceTables } = useAdminWorkspace();
@@ -14,7 +14,7 @@ export const useAdminFetchOrderBase = (workspaceId: string | undefined) => {
   const [endDate, setEndDate] = useState<Date | null>(new Date());
   const [tableNumber, setTableNumber] = useState<string>('ALL');
   const [sortOrder, setSortOrder] = useState<string>('LATEST');
-  const [orderStatuses, setOrderStatuses] = useState<OrderStatus[]>([]);
+  const [orderStatuses, setOrderStatuses] = useState<OrderStatus[]>([...DEFAULT_TOTAL_ORDER_STATUSES]);
 
   useEffect(() => {
     if (workspaceId) {
@@ -38,7 +38,7 @@ export const useAdminFetchOrderBase = (workspaceId: string | undefined) => {
     setEndDate(new Date());
     setTableNumber('ALL');
     setSortOrder('LATEST');
-    setOrderStatuses([]);
+    setOrderStatuses([...DEFAULT_TOTAL_ORDER_STATUSES]);
   }, []);
 
   return {

--- a/src/pages/admin/order/AdminTotalOrder.tsx
+++ b/src/pages/admin/order/AdminTotalOrder.tsx
@@ -118,7 +118,7 @@ function AdminTotalOrder() {
         <SearchInput value={searchKeyword} onChange={(e) => setSearchKeyword(e.target.value)} placeholder="주문번호나 주문자명을 입력해주세요." />
         <StatCardsWrapper>
           <StatCard title="총 주문 건 수" value={totalCount.toLocaleString()} unit="건" height={100} />
-          <StatCard title="총 매출액" value={totalRevenue.toLocaleString()} unit="원" height={100} />
+          <StatCard title="총 주문 금액" value={totalRevenue.toLocaleString()} unit="원" height={100} />
         </StatCardsWrapper>
         {orders.length > 0 ? (
           <OrderListContainer>


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Fragmentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

전체주문조회 화면에서 주문 상태 필터에 `주문 취소`를 추가했습니다.
기본 선택 상태와 초기화 상태에서는 `주문 취소`를 제외하도록 변경해, 
최초 진입 시에는 취소 주문이 합계와 목록에 포함되지 않도록 정리했습니다.

https://github.com/user-attachments/assets/b12eb0ff-a0b5-4e95-9ddd-f9508f1b2d01


추가로 통계 카드의 `총 매출액` 문구를 실제 동작에 맞게 `총 주문 금액`으로 수정했습니다.
필터 선택에 따라 합계 금액이 바뀌는 기존 로직은 그대로 유지됩니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

리뷰 포인트:
- `src/hooks/admin/useAdminFetchOrderBase.tsx`
- `src/constants/data/adminOrderData.ts`
