### PR TITLE
DEPLOY - areOrdersEquivalent orderProducts 길이 불일치 시 크래시 방지

### DIFF
--- a/src/utils/memoCompareFunction.ts
+++ b/src/utils/memoCompareFunction.ts
@@ -1,14 +1,9 @@
 import { Order } from '@@types/index';
 
 export const areOrdersEquivalent = (prevOrder: Order, nextOrder: Order) => {
-  const isSameOrderId = prevOrder.id === nextOrder.id;
-  const hasSameStatus = prevOrder.status === nextOrder.status;
-  const hasSameProductsLength = prevOrder.orderProducts.length === nextOrder.orderProducts.length;
+  if (prevOrder.id !== nextOrder.id) return false;
+  if (prevOrder.status !== nextOrder.status) return false;
+  if (prevOrder.orderProducts.length !== nextOrder.orderProducts.length) return false;
 
-  const areAllServedCountsEqual = prevOrder.orderProducts.every((prevProduct, index) => {
-    const nextProduct = nextOrder.orderProducts[index];
-    return prevProduct.servedCount === nextProduct.servedCount;
-  });
-
-  return isSameOrderId && hasSameStatus && hasSameProductsLength && areAllServedCountsEqual;
+  return prevOrder.orderProducts.every((prevProduct, index) => prevProduct.servedCount === nextOrder.orderProducts[index].servedCount);
 };


### PR DESCRIPTION
## Summary
- 어드민 실시간 주문 페이지(`/admin/workspace/:workspaceId/order/realtime`)에서 발생한 런타임 크래시 핫픽스
- `areOrdersEquivalent`가 `orderProducts` 길이 비교를 별도 변수에만 저장하고 early-return을 하지 않아, 길이가 다를 때 `every` 콜백이 `undefined` 요소의 `.servedCount`를 참조해 터지던 문제 수정

## 원인
[Sentry KIO-SCHOOL-BN](https://kioschool.sentry.io/issues/7475862033) — `TypeError: undefined is not an object (evaluating 'c.servedCount')` (이벤트 5건 / 사용자 5명)

기존 코드는 `hasSameProductsLength`를 계산만 해두고 곧바로 `every`를 실행해서, `prevOrder.orderProducts`가 `nextOrder.orderProducts`보다 길면 `nextOrder.orderProducts[index]`가 `undefined`가 되어 다음 줄 `nextProduct.servedCount`에서 크래시. `React.memo` 비교 함수로 4곳(`ServedOrderCard`, `PaidOrderCard`, `NotPaidOrderCard`, `TitledOrderStatusList`)에서 사용 중이라 주문 상품 개수가 변하는 시나리오에서 ErrorBoundary가 떴음.

## 변경
- id / status / `orderProducts.length` 불일치 시 즉시 `false` 반환하는 early-return으로 정리
- 길이 일치가 보장된 뒤에만 `servedCount` 비교 실행

## Test plan
- [ ] 어드민 실시간 주문 페이지에서 주문에 상품 추가/취소가 발생하는 흐름 동작 확인
- [ ] React.memo 적용된 카드들(`ServedOrderCard`, `PaidOrderCard`, `NotPaidOrderCard`)이 상품 수 변경 시 정상 리렌더되는지 확인
- [ ] Sentry 이슈 재발 여부 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)