### PR TITLE
FIX - prerender type 수정

### DIFF
--- a/src/prerender.tsx
+++ b/src/prerender.tsx
@@ -1,5 +1,6 @@
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
+import type { ComponentProps } from 'react';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 import { Route, Routes } from 'react-router-dom';
@@ -36,6 +37,8 @@ interface FakeDocument {
   createElement: (tagName: string) => FakeElement;
   createTextNode: (text: string) => FakeNode & { textContent: string };
 }
+
+type CacheProviderValue = ComponentProps<typeof CacheProvider>['value'];
 
 function createFakeElement(styleSheets: FakeDocument['styleSheets'], tagName: string): FakeElement {
   const element: FakeElement = {
@@ -107,7 +110,7 @@ export async function prerender({ url }: PrerenderArguments): Promise<PrerenderR
   ensurePrerenderDocument();
   const pathname = getPathname(url);
   const seo = getMarketingSeoByPathname(pathname);
-  const cache = createCache({ key: 'css' });
+  const cache = createCache({ key: 'css' }) as CacheProviderValue;
   const html = renderToString(
     <CacheProvider value={cache}>
       <HelmetProvider>


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

Amplify dev 빌드에서 `src/prerender.tsx` 의 Emotion cache 타입 충돌로 `build:dev` 가 실패하던 문제를 수정했습니다.

- prerender 전용 cache 값을 `CacheProvider` 가 기대하는 타입 기준으로 맞췄습니다.
- fresh install 환경에서 발생하던 `@emotion/cache` 타입 불일치로 인한 TypeScript 에러를 우회합니다.
- 로컬에서 `yarn build:dev` 로 prerender `/`, `/info` 생성까지 다시 확인했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- `src/prerender.tsx`
  - 런타임 동작 변경은 없고, CI/Amplify fresh install 환경에서만 발생하던 타입 불일치를 정리한 수정입니다.
  - prerender 로직 자체는 그대로 유지됩니다.
