### PR TITLE
FIX - 계좌번호 입력 시 공백 제거

### DIFF
--- a/src/components/admin/account/register/RegisterAccount.tsx
+++ b/src/components/admin/account/register/RegisterAccount.tsx
@@ -6,7 +6,7 @@ import { colFlex, rowFlex } from '@styles/flexStyles';
 import NewAppInput from '@components/common/input/NewAppInput';
 import { adminBanksAtom } from '@jotai/admin/atoms';
 import { externalSidebarAtom } from '@jotai/atoms';
-import { removeWhitespace } from '@utils/formatNumber';
+import { normalizeAccountNumber } from '@utils/formatNumber';
 import { useAtomValue, useSetAtom } from 'jotai';
 import NewCommonButton from '@components/common/button/NewCommonButton';
 import { RIGHT_SIDEBAR_ACTION } from '@@types/index';
@@ -73,7 +73,7 @@ function RegisterAccount() {
   };
 
   const handleAccountNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.target.value = removeWhitespace(event.target.value);
+    event.target.value = normalizeAccountNumber(event.target.value);
   };
 
   const handleReset = () => {
@@ -89,7 +89,7 @@ function RegisterAccount() {
 
   const registerHandler = async () => {
     const accountHolder = accountHolderRef.current?.value;
-    const accountNumber = removeWhitespace(accountNumberRef.current?.value ?? '');
+    const accountNumber = normalizeAccountNumber(accountNumberRef.current?.value ?? '');
 
     if (selectedBankId === '') {
       alert('은행을 선택해주세요.');
@@ -108,11 +108,6 @@ function RegisterAccount() {
 
     if (accountNumberRef.current) {
       accountNumberRef.current.value = accountNumber;
-    }
-
-    if (accountNumber.includes('-')) {
-      alert('하이픈(-)없이 숫자만 입력해주세요');
-      return;
     }
 
     const response = await registerAccount(Number(selectedBankId), accountNumber, accountHolder);

--- a/src/components/admin/account/register/RegisterAccount.tsx
+++ b/src/components/admin/account/register/RegisterAccount.tsx
@@ -6,6 +6,7 @@ import { colFlex, rowFlex } from '@styles/flexStyles';
 import NewAppInput from '@components/common/input/NewAppInput';
 import { adminBanksAtom } from '@jotai/admin/atoms';
 import { externalSidebarAtom } from '@jotai/atoms';
+import { removeWhitespace } from '@utils/formatNumber';
 import { useAtomValue, useSetAtom } from 'jotai';
 import NewCommonButton from '@components/common/button/NewCommonButton';
 import { RIGHT_SIDEBAR_ACTION } from '@@types/index';
@@ -71,6 +72,10 @@ function RegisterAccount() {
     setSelectedBankId(event.target.value);
   };
 
+  const handleAccountNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.target.value = removeWhitespace(event.target.value);
+  };
+
   const handleReset = () => {
     setSelectedBankId('');
 
@@ -84,7 +89,7 @@ function RegisterAccount() {
 
   const registerHandler = async () => {
     const accountHolder = accountHolderRef.current?.value;
-    const accountNumber = accountNumberRef.current?.value;
+    const accountNumber = removeWhitespace(accountNumberRef.current?.value ?? '');
 
     if (selectedBankId === '') {
       alert('은행을 선택해주세요.');
@@ -99,6 +104,10 @@ function RegisterAccount() {
     if (!accountNumber || accountNumber.trim() === '') {
       alert('계좌번호를 입력해주세요.');
       return;
+    }
+
+    if (accountNumberRef.current) {
+      accountNumberRef.current.value = accountNumber;
     }
 
     if (accountNumber.includes('-')) {
@@ -128,7 +137,14 @@ function RegisterAccount() {
         </InputColContainer>
         <InputColContainer>
           <InputLabel>계좌번호</InputLabel>
-          <NewAppInput placeholder={'(-)를 제외한 계좌번호를 입력해주세요.'} type={'text'} ref={accountNumberRef} width={220} height={50} />
+          <NewAppInput
+            placeholder={'(-)를 제외한 계좌번호를 입력해주세요.'}
+            type={'text'}
+            ref={accountNumberRef}
+            width={220}
+            height={50}
+            onChange={handleAccountNumberChange}
+          />
         </InputColContainer>
       </InputContainer>
       <SubmitContainer>

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,9 +1,15 @@
+const WHITESPACE_REGEX = /\s+/g;
+
 export function formatNumber(n: number): string {
   return n.toLocaleString('ko-KR');
 }
 
 export function formatCurrency(n: number): string {
   return `${formatNumber(n)}원`;
+}
+
+export function removeWhitespace(value: string): string {
+  return value.replace(WHITESPACE_REGEX, '');
 }
 
 function pad2(n: number): string {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,4 +1,4 @@
-const WHITESPACE_REGEX = /\s+/g;
+export const NON_DIGIT_REGEX = /[^0-9]/g;
 
 export function formatNumber(n: number): string {
   return n.toLocaleString('ko-KR');
@@ -8,8 +8,8 @@ export function formatCurrency(n: number): string {
   return `${formatNumber(n)}원`;
 }
 
-export function removeWhitespace(value: string): string {
-  return value.replace(WHITESPACE_REGEX, '');
+export function normalizeAccountNumber(value: string): string {
+  return value.replace(NON_DIGIT_REGEX, '');
 }
 
 function pad2(n: number): string {


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

- 계좌번호 입력 정제 로직을 공용 유틸 `normalizeAccountNumber`로 분리했습니다.
- 계좌번호 입력 단계에서 공백, 하이픈, 문자 입력이 모두 즉시 제거되도록 변경했습니다.
- 제출 시에도 동일한 정제 로직을 다시 적용해 붙여넣기된 값까지 숫자만 남도록 맞췄습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)