### PR TITLE
ADD - info 페이지에 github 추가

### DIFF
--- a/src/components/user/info/InfoCtaSection.tsx
+++ b/src/components/user/info/InfoCtaSection.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 import { motion } from 'framer-motion';
+import { RiGithubFill, RiInstagramLine } from '@remixicon/react';
 import { Link } from 'react-router-dom';
-import { RiInstagramLine } from '@remixicon/react';
 import { colFlex, rowFlex } from '@styles/flexStyles';
+import { URLS } from '@constants/urls';
 import { mobileMediaQuery } from '@styles/globalStyles';
 import { captionTypography, headingTypography, subheadingTypography } from '@styles/landingTypography';
 import { Color } from '@resources/colors';
@@ -70,8 +71,14 @@ const Reassurance = styled.p`
   ${captionTypography};
 `;
 
-const ContactLink = styled.a`
+const ContactLinkRow = styled.div`
   margin-top: 56px;
+  gap: 12px;
+  flex-wrap: wrap;
+  ${rowFlex({ justify: 'center', align: 'center' })};
+`;
+
+const ContactLink = styled.a`
   padding: 10px 20px;
   background: #f2f4f6;
   color: #3c3530;
@@ -105,10 +112,16 @@ function InfoCtaSection() {
         <Subtitle>가입부터 주점 운영까지, 3분이면 준비 끝</Subtitle>
         <CtaButton to={ADMIN_ROUTES.HOME}>{isLoggedIn ? '어드민 홈으로' : '무료로 시작하기'}</CtaButton>
         <Reassurance>별도 비용 없이 시작할 수 있어요</Reassurance>
-        <ContactLink href="https://www.instagram.com/kioschool/" target="_blank" rel="noopener noreferrer">
-          <RiInstagramLine size={16} />
-          키오스쿨 문의하기
-        </ContactLink>
+        <ContactLinkRow>
+          <ContactLink href={URLS.EXTERNAL.GITHUB} target="_blank" rel="noopener noreferrer" aria-label="키오스쿨 GitHub 저장소 보기">
+            <RiGithubFill size={16} />
+            키오스쿨 GitHub
+          </ContactLink>
+          <ContactLink href={URLS.EXTERNAL.INSTAGRAM} target="_blank" rel="noopener noreferrer" aria-label="키오스쿨 인스타그램으로 문의하기">
+            <RiInstagramLine size={16} />
+            키오스쿨 문의하기
+          </ContactLink>
+        </ContactLinkRow>
       </ContentWrapper>
     </Container>
   );

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -12,6 +12,7 @@ export const URLS = {
 
   EXTERNAL: {
     NOTION_FAQ: 'https://ji-in.notion.site/FAQ-09eb07eac4a34ab4aa883727994e0b08?pvs=4',
+    GITHUB: 'https://github.com/KioSchool',
     INSTAGRAM: 'https://www.instagram.com/kioschool/',
     YOUTUBE: 'https://www.youtube.com/watch?v=4tZjnj48hBk',
     KIO_SCHOOL: 'https://kio-school.com',


### PR DESCRIPTION
## 📚 개요

Info page에 Github Link를 추가했습니다.

**BEFORE**

<img width="1223" height="888" alt="image" src="https://github.com/user-attachments/assets/b1ff9a73-3185-4f81-bfcb-42a254a47fe9" />


**AFTER**

<img width="2406" height="1242" alt="image" src="https://github.com/user-attachments/assets/29d2ad89-daf6-4521-8116-039adfb6b3ca" />


## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

리뷰가 비교적 꼼꼼히 이루어져야할 부분이나 파일을 여기다 적어주거나
해당 로직에 직접 코멘트를 달아도 좋습니다