### PR TITLE
EDIT - 도네이션 funnel 개선 및 슈퍼어드민·마이페이지 UI 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,7 @@ function App() {
         <Route path={SUPER_ADMIN_ROUTES.FESTIVAL_CALENDAR} element={<SuperAdminFestivalCalendar />} />
 
         <Route path={USER_ROUTES.LOGIN} element={<Login />} />
+        <Route path={ADMIN_ROUTES.MY_INFO} element={<AdminMyInfo />} />
 
         <Route element={<PcOnlyLayout />}>
           <Route path={USER_ROUTES.REGISTER} element={<Register />} />
@@ -97,7 +98,6 @@ function App() {
           <Route path={USER_ROUTES.EMAIL_DOMAINS} element={<UserEmailDomain />} />
 
           <Route path={ADMIN_ROUTES.HOME} element={<AdminHome />} />
-          <Route path={ADMIN_ROUTES.MY_INFO} element={<AdminMyInfo />} />
           <Route path={ADMIN_ROUTES.REGISTER_ACCOUNT} element={<AdminAccount />} />
           <Route path={ADMIN_ROUTES.WORKSPACE} element={<AdminWorkspace />} />
           <Route path={ADMIN_ROUTES.WORKSPACE_EDIT} element={<AdminWorkspaceEdit />} />

--- a/src/components/admin/insight/DonationSection.tsx
+++ b/src/components/admin/insight/DonationSection.tsx
@@ -31,9 +31,10 @@ const Tail = styled.div`
 interface DonationSectionProps {
   workspaceId: string;
   workspaceName: string;
+  yesterdayRevenue?: number;
 }
 
-function DonationSection({ workspaceId, workspaceName }: DonationSectionProps) {
+function DonationSection({ workspaceId, workspaceName, yesterdayRevenue }: DonationSectionProps) {
   const [amount, setAmount] = useState<number>(DEFAULT_AMOUNT);
   const { reportDonationAmountClick } = useInsightDiscordReport();
 
@@ -45,7 +46,7 @@ function DonationSection({ workspaceId, workspaceName }: DonationSectionProps) {
   return (
     <Section>
       <Label>KioSchool 응원하기</Label>
-      <PresetChips selectedAmount={amount} onSelect={handlePresetSelect} />
+      <PresetChips selectedAmount={amount} yesterdayRevenue={yesterdayRevenue} onSelect={handlePresetSelect} />
       <DonationQr amount={amount} />
       <Tail>송금자명에 닉네임이나 주점명을 적어주시면 운영팀이 확인하기 쉬워요.</Tail>
     </Section>

--- a/src/components/admin/insight/ShareSupportModal.tsx
+++ b/src/components/admin/insight/ShareSupportModal.tsx
@@ -188,7 +188,7 @@ function ShareSupportModal({ card, workspaceId, workspaceName, onClose }: Props)
           </ActionButton>
         </ActionRow>
 
-        <DonationSection workspaceId={workspaceId} workspaceName={workspaceName} />
+        <DonationSection workspaceId={workspaceId} workspaceName={workspaceName} yesterdayRevenue={card.payload.totalRevenue} />
       </Modal>
     </Overlay>
   );

--- a/src/components/admin/insight/donation/PresetChips.tsx
+++ b/src/components/admin/insight/donation/PresetChips.tsx
@@ -41,10 +41,18 @@ const ChipIllustration = styled.img`
   object-fit: contain;
 `;
 
-const ChipAmount = styled.div`
+const ChipMain = styled.div`
   font-size: 14px;
   font-weight: 700;
   color: ${Color.BLACK};
+  text-align: center;
+  word-break: keep-all;
+`;
+
+const ChipSub = styled.div`
+  font-size: 11px;
+  font-weight: 500;
+  color: ${Color.GREY};
 `;
 
 const ChipDescription = styled.div`
@@ -54,30 +62,44 @@ const ChipDescription = styled.div`
   line-height: 1.3;
 `;
 
+const MAX_PRESET_AMOUNT = 1000000;
+
 function pickRandomCustomIllustration(): string {
   const idx = Math.floor(Math.random() * CUSTOM_RANDOM_ILLUSTRATIONS.length);
   return CUSTOM_RANDOM_ILLUSTRATIONS[idx];
 }
 
+function formatRevenuePercent(amount: number, revenue: number): string {
+  const ratio = (amount / revenue) * 100;
+  return ratio >= 10 ? `${ratio.toFixed(0)}%` : `${ratio.toFixed(1)}%`;
+}
+
 interface PresetChipsProps {
   selectedAmount: number;
+  yesterdayRevenue?: number;
   onSelect: (option: PresetOption) => void;
 }
 
-function PresetChips({ selectedAmount, onSelect }: PresetChipsProps) {
+function PresetChips({ selectedAmount, yesterdayRevenue, onSelect }: PresetChipsProps) {
   const customIllustration = useMemo(() => pickRandomCustomIllustration(), []);
+  const usePercentMode = yesterdayRevenue != null && yesterdayRevenue >= MAX_PRESET_AMOUNT;
 
   return (
     <Row>
       {PRESET_OPTIONS.map((option) => {
         const isCustom = option.amount === CUSTOM_AMOUNT_SENTINEL;
         const illustration = isCustom ? customIllustration : option.illustration;
-        const amountLabel = isCustom ? '자유' : `${option.amount.toLocaleString()}원`;
         const selected = selectedAmount === option.amount;
+        const amountLabel = `${option.amount.toLocaleString()}원`;
+
+        const showPercent = usePercentMode && !isCustom;
+        const mainLabel = isCustom ? '자유' : showPercent ? `어제 매출의 ${formatRevenuePercent(option.amount, yesterdayRevenue!)}` : amountLabel;
+
         return (
           <Chip key={option.character} selected={selected} onClick={() => onSelect(option)} type="button">
             <ChipIllustration src={illustration} alt={`${option.character} 마스코트`} />
-            <ChipAmount>{amountLabel}</ChipAmount>
+            <ChipMain>{mainLabel}</ChipMain>
+            {showPercent && <ChipSub>{amountLabel}</ChipSub>}
             <ChipDescription>{option.description}</ChipDescription>
           </Chip>
         );

--- a/src/components/admin/insight/donation/donationConstants.ts
+++ b/src/components/admin/insight/donation/donationConstants.ts
@@ -6,7 +6,7 @@ import c5KCoffee from '@resources/image/donation/c5-k-coffee.webp';
 import c6TrioCheers from '@resources/image/donation/c6-trio-cheers.webp';
 
 export const MIN_AMOUNT = 1000;
-export const DEFAULT_AMOUNT = 50000;
+export const DEFAULT_AMOUNT = 30000;
 
 export const CUSTOM_AMOUNT_SENTINEL = 0;
 

--- a/src/components/admin/my-info/MyInfoCard.tsx
+++ b/src/components/admin/my-info/MyInfoCard.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { colFlex } from '@styles/flexStyles';
+import { mobileMediaQuery } from '@styles/globalStyles';
 
 const CardContainer = styled.div`
   width: 295px;
@@ -19,6 +20,12 @@ const CardContainer = styled.div`
     transform: translateY(-4px);
     box-shadow: 0 4px 20px 0 rgba(92, 92, 92, 0.1);
   }
+
+  ${mobileMediaQuery} {
+    width: 100%;
+    height: auto;
+    padding: 24px 0;
+  }
 `;
 
 const IconWrapper = styled.div`
@@ -29,6 +36,10 @@ const Label = styled.div`
   color: #464a4d;
   font-size: 20px;
   font-weight: 700;
+
+  ${mobileMediaQuery} {
+    font-size: 16px;
+  }
 `;
 
 interface MyInfoCardProps {

--- a/src/components/admin/my-info/MyInfoContent.tsx
+++ b/src/components/admin/my-info/MyInfoContent.tsx
@@ -1,19 +1,31 @@
 import styled from '@emotion/styled';
 import { rowFlex, colFlex } from '@styles/flexStyles';
+import { mobileMediaQuery } from '@styles/globalStyles';
 import { User, UserRole } from '@@types/index';
 import { myInfoCardsData } from '@constants/data/myInfoData';
 import { useMyInfoActions } from '@hooks/admin/useMyInfoActions';
 import MyInfoCard from './MyInfoCard';
 
 const Container = styled.div`
+  width: 100%;
   gap: 40px;
   ${colFlex({ justify: 'center', align: 'center' })}
+
+  ${mobileMediaQuery} {
+    gap: 20px;
+    padding: 20px 0;
+  }
 `;
 
 const CardsContainer = styled.div`
   width: 95%;
   gap: 10px;
   ${rowFlex({ justify: 'center', align: 'center' })}
+
+  ${mobileMediaQuery} {
+    width: 90%;
+    ${colFlex({ justify: 'center', align: 'stretch' })}
+  }
 `;
 
 interface MyInfoContentProps {

--- a/src/components/admin/workspace/AddworkspaceModalContent.tsx
+++ b/src/components/admin/workspace/AddworkspaceModalContent.tsx
@@ -67,6 +67,8 @@ const UnderlineInput = styled.input`
   }
 `;
 
+const MAX_WORKSPACE_NAME_LENGTH = 30;
+
 interface AddWorkspaceModalContentProps {
   closeModal: () => void;
 }
@@ -90,7 +92,13 @@ function AddWorkspaceModalContent({ closeModal }: AddWorkspaceModalContentProps)
     <ModalContentContainer>
       <CloseButton onClick={closeModal} />
       <Title>주점명을 입력해주세요.</Title>
-      <UnderlineInput value={workspaceName} onChange={(e) => setWorkspaceName(e.target.value)} placeholder="주점 이름 입력" autoFocus />
+      <UnderlineInput
+        value={workspaceName}
+        onChange={(e) => setWorkspaceName(e.target.value)}
+        placeholder={`주점 이름 입력 (최대 ${MAX_WORKSPACE_NAME_LENGTH}자)`}
+        maxLength={MAX_WORKSPACE_NAME_LENGTH}
+        autoFocus
+      />
       <NewCommonButton size="sm" onClick={createHandler} disabled={isButtonDisabled}>
         생성하기
       </NewCommonButton>

--- a/src/components/admin/workspace/dashboard/InsightCard.tsx
+++ b/src/components/admin/workspace/dashboard/InsightCard.tsx
@@ -11,9 +11,8 @@ const Container = styled.div`
   width: 100%;
   box-sizing: border-box;
   background: ${InsightDesignTokens.card.background};
-  border: 1px solid ${InsightDesignTokens.card.border};
   border-radius: ${InsightDesignTokens.card.radius};
-  box-shadow: ${InsightDesignTokens.card.shadow};
+  box-shadow: ${InsightDesignTokens.card.shadow}, 0 0 18px rgba(255, 145, 66, 0.14), 0 0 32px rgba(255, 145, 66, 0.16), 0 0 56px rgba(255, 145, 66, 0.09);
   padding: 14px 21px;
   gap: 14px;
   ${colFlex({ align: 'stretch' })};

--- a/src/components/super-admin/dashboard/DashboardSections.tsx
+++ b/src/components/super-admin/dashboard/DashboardSections.tsx
@@ -11,6 +11,7 @@ import ActiveWorkspaceSection from './ActiveWorkspaceSection';
 import FunnelSection from './FunnelSection';
 import TopWorkspacesSection from './TopWorkspacesSection';
 import OnboardingTimeSection from './OnboardingTimeSection';
+import OperationsToolsSection from './OperationsToolsSection';
 
 const Stack = styled.div`
   width: 100%;
@@ -39,6 +40,7 @@ function DashboardSections({ data }: DashboardSectionsProps) {
       <FunnelSection funnel={data.insights.funnel} />
       <OnboardingTimeSection stats={data.insights.onboardingTimeStats} />
       <TopWorkspacesSection items={data.insights.topWorkspaces} />
+      <OperationsToolsSection />
     </Stack>
   );
 }

--- a/src/components/super-admin/dashboard/OperationsToolsSection.tsx
+++ b/src/components/super-admin/dashboard/OperationsToolsSection.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import styled from '@emotion/styled';
+import { format, subDays } from 'date-fns';
+import { toast } from 'react-toastify';
+import { Color } from '@resources/colors';
+import { colFlex, rowFlex } from '@styles/flexStyles';
+import { mobileMediaQuery } from '@styles/globalStyles';
+import useSuperAdminInsightCard from '@hooks/super-admin/useSuperAdminInsightCard';
+import SectionTitle from './SectionTitle';
+
+const Card = styled.div`
+  width: 100%;
+  box-sizing: border-box;
+  padding: 16px;
+  background: ${Color.WHITE};
+  border: 1px solid #e8eef2;
+  border-radius: 12px;
+  gap: 12px;
+  ${colFlex({ align: 'stretch' })};
+`;
+
+const ToolLabel = styled.div`
+  font-size: 13px;
+  font-weight: 600;
+  color: #464a4d;
+`;
+
+const ToolDescription = styled.div`
+  font-size: 12px;
+  color: ${Color.GREY};
+  line-height: 1.4;
+`;
+
+const ControlRow = styled.div`
+  gap: 8px;
+  flex-wrap: wrap;
+  ${rowFlex({ justify: 'flex-start', align: 'center' })};
+
+  ${mobileMediaQuery} {
+    ${rowFlex({ justify: 'flex-start', align: 'stretch' })};
+    flex-direction: column;
+  }
+`;
+
+const DateInput = styled.input`
+  height: 36px;
+  padding: 0 10px;
+  font-size: 13px;
+  border: 1px solid #e8eef2;
+  border-radius: 8px;
+  background: ${Color.WHITE};
+  color: #464a4d;
+`;
+
+const RegenerateButton = styled.button`
+  height: 36px;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: ${Color.WHITE};
+  background: ${Color.KIO_ORANGE};
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: ${Color.KIO_ORANGE_DARK};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+function getYesterdayString(): string {
+  return format(subDays(new Date(), 1), 'yyyy-MM-dd');
+}
+
+function OperationsToolsSection() {
+  const { regenerateInsightCard } = useSuperAdminInsightCard();
+  const [date, setDate] = useState<string>(getYesterdayString());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleRegenerate = () => {
+    if (!date) {
+      toast.warn('날짜를 선택해주세요.');
+      return;
+    }
+    setIsSubmitting(true);
+    regenerateInsightCard(date)
+      .then(() => {
+        toast.success(`${date} 인사이트 카드를 재생성했어요.`);
+      })
+      .catch(() => {
+        toast.error('재생성에 실패했어요. 잠시 후 다시 시도해주세요.');
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  };
+
+  return (
+    <div>
+      <SectionTitle>운영 도구</SectionTitle>
+      <Card>
+        <ToolLabel>인사이트 카드 수동 재생성</ToolLabel>
+        <ToolDescription>선택한 날짜의 어드민 인사이트 카드를 다시 만들어요. 데이터 보정이나 카피 변경 후 사용하세요.</ToolDescription>
+        <ControlRow>
+          <DateInput type="date" value={date} onChange={(e) => setDate(e.target.value)} max={getYesterdayString()} />
+          <RegenerateButton type="button" onClick={handleRegenerate} disabled={isSubmitting}>
+            {isSubmitting ? '재생성 중...' : '재생성'}
+          </RegenerateButton>
+        </ControlRow>
+      </Card>
+    </div>
+  );
+}
+
+export default OperationsToolsSection;

--- a/src/hooks/super-admin/useSuperAdminInsightCard.tsx
+++ b/src/hooks/super-admin/useSuperAdminInsightCard.tsx
@@ -1,0 +1,13 @@
+import useApi from '@hooks/useApi';
+
+function useSuperAdminInsightCard() {
+  const { superAdminApi } = useApi();
+
+  const regenerateInsightCard = (date: string) => {
+    return superAdminApi.post('/insight-card/regenerate', null, { params: { date } });
+  };
+
+  return { regenerateInsightCard };
+}
+
+export default useSuperAdminInsightCard;

--- a/src/pages/admin/order/AdminOrderStatistics.tsx
+++ b/src/pages/admin/order/AdminOrderStatistics.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
 import { format } from 'date-fns';
 import AppContainer from '@components/common/container/AppContainer';
 import { colFlex, rowFlex } from '@styles/flexStyles';
@@ -10,9 +12,13 @@ import ContentCard from '@components/common/card/ContentCard';
 import RefreshSpinIcon from '@components/common/refresh/RefreshSpinIcon';
 import HourlySalesChart from '@components/admin/order/statistic/HourlySalesChart';
 import PopularProductsSection from '@components/admin/order/statistic/PopularProductsSection';
+import InsightCard from '@components/admin/workspace/dashboard/InsightCard';
+import ShareSupportModal from '@components/admin/insight/ShareSupportModal';
 import { useAdminFetchDailyStatistics } from '@hooks/admin/useAdminFetchDailyStatistics';
+import { adminWorkspaceAtom } from '@jotai/admin/atoms';
 import { formatMinutesToTime } from '@utils/formatDate';
 import { Color } from '@resources/colors';
+import { InsightCardResponse } from '@@types/index';
 
 const Container = styled.div`
   width: 95%;
@@ -79,6 +85,9 @@ const isValidDate = (dateStr: string) => !isNaN(new Date(dateStr).getTime());
 function AdminOrderStatistics() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
   const { selectedDate, setSelectedDate, statistics, isLoading, manualRefetch } = useAdminFetchDailyStatistics(workspaceId);
+  const workspace = useAtomValue(adminWorkspaceAtom);
+  const [shareCard, setShareCard] = useState<InsightCardResponse | null>(null);
+  const insightEnabled = import.meta.env.VITE_INSIGHT_CARD_ENABLED === 'true';
 
   const dateLabel = format(selectedDate, 'yyyy년 MM월 dd일');
   const comparison = statistics?.previousDayComparison;
@@ -104,6 +113,8 @@ function AdminOrderStatistics() {
             </UpdateInfo>
           )}
         </FilterContainer>
+
+        {insightEnabled && workspaceId && <InsightCard workspaceId={workspaceId} workspaceName={workspace.name} onShareClick={setShareCard} />}
 
         {isLoading && !statistics && <UpdateLabel>로딩 중...</UpdateLabel>}
 
@@ -148,6 +159,9 @@ function AdminOrderStatistics() {
             </ContentCard>
             <PopularProductsSection popularProducts={statistics.popularProducts} />
           </SectionRow>
+        )}
+        {shareCard && workspaceId && (
+          <ShareSupportModal card={shareCard} workspaceId={workspaceId} workspaceName={workspace.name} onClose={() => setShareCard(null)} />
         )}
       </Container>
     </AppContainer>


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [ ] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Fragmentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

도네이션 전환율을 끌어올리기 위한 funnel 개선과, 운영/UX 정리를 한 묶음으로 처리했습니다.

### 1. 도네이션 funnel 개선
- **기본 응원 금액 50,000원 → 30,000원**으로 인하 (심리적 진입장벽 완화)
- **InsightCard 디자인** — 회색 border 제거, KIO_ORANGE 기반 3겹 halo glow 적용해 시선 유도
- **주문 통계 페이지에도 InsightCard 노출** — 대시보드 외에 후원 노출 채널을 한 곳 더 확보 (트래픽이 높은 페이지에서 매출/감사 모먼트와 함께 노출)
- **칩 금액을 어제 매출 대비 %로 표기** — 어제 매출이 100만원 이상이면 메인을 `어제 매출의 3%` 식으로 보여주고, 절대 금액은 sub로 내림. 큰 매출 주점일수록 작은 숫자가 메인이 되어 부담 완화

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/1eaa959b-b080-42f8-b52d-8596d0806a55" />

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/ad315c02-a63d-4b43-81bd-d8de4564f576" />


<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/cb839699-3e75-4e40-9373-f316fe98e286" />


### 2. 슈퍼어드민 운영 도구
- `SuperAdminDashboard` 하단에 **"운영 도구" 섹션** 신설
- **인사이트 카드 수동 재생성 UI** 추가 (`POST /super-admin/insight-card/regenerate?date=YYYY-MM-DD`) — 데이터 보정/카피 변경 후 즉시 갱신 용도
- 향후 다른 운영 버튼들도 같은 섹션에 모을 수 있는 구조

### 3. 마이페이지 정리
- `ADMIN_ROUTES.MY_INFO`를 `PcOnlyLayout` 밖으로 이동 → 모바일에서도 접근 가능
- `MyInfoCard`/`MyInfoContent` 모바일 반응형 추가 (카드 세로 배열, 폰트/패딩 스케일)

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/3161de25-ecd1-4c88-b396-2654dd603b8c" />

### 4. 워크스페이스 생성 입력 제한
- 주점명 input에 **30자 제한** (공백 포함) + placeholder에 명시


## 🕐 리뷰 예상 시간

> 10m

## ❗❗ 중요한 변경점(Option)

- **Ternary 사용 위반 2건**
  - `src/components/super-admin/dashboard/OperationsToolsSection.tsx` — 버튼 label `{isSubmitting ? '재생성 중...' : '재생성'}` (로딩 상태 표기에 한정된 단순 ternary)
  - `src/components/admin/insight/donation/PresetChips.tsx` — `mainLabel` 분기에 중첩 ternary 사용 (`isCustom` / `showPercent` / 기본). 가독성 위해 `match` 또는 함수로 분리가 더 안전할지 의견 부탁드립니다.
- **새 endpoint 의존**: 슈퍼어드민 인사이트 카드 재생성 기능은 `POST /super-admin/insight-card/regenerate?date=...` 가 서버에 배포되어 있어야 동작합니다.
- **마이페이지 라우트 가드 변경**: `MY_INFO`가 `PcOnlyLayout` 밖으로 빠지면서 모바일에서도 접근 가능합니다. 의도된 변경이지만 다른 admin 라우트와 동작 분기가 생긴 점 참고 부탁드립니다.
- **InsightCard 노출 의존성**: 통계 페이지의 InsightCard도 기존과 동일하게 `VITE_INSIGHT_CARD_ENABLED === 'true'` + 어제 매출 50만원 이상 조건에서만 렌더됩니다.
