### PR TITLE
FIX - 계좌 정보 변경 오류 수정

### DIFF
--- a/src/components/user/order/orderWait/OrderAccountInfo.tsx
+++ b/src/components/user/order/orderWait/OrderAccountInfo.tsx
@@ -55,7 +55,11 @@ const Value = styled.div`
   ${rowFlex({ justify: 'start', align: 'center' })}
 `;
 
-function OrderAccountInfo() {
+interface OrderAccountInfoProps {
+  account?: Account;
+}
+
+function OrderAccountInfo({ account }: OrderAccountInfoProps) {
   const [searchParams] = useSearchParams();
   const workspaceId = searchParams.get('workspaceId');
   const [accountInfo, setAccountInfo] = useState<Account>(defaultAccountValue);
@@ -63,10 +67,15 @@ function OrderAccountInfo() {
   const { fetchWorkspaceAccount } = useWorkspace();
 
   const getAccountInfo = async () => {
-    const account = await fetchWorkspaceAccount(workspaceId);
-    if (!account) return;
+    if (account) {
+      setAccountInfo(account);
+      return;
+    }
 
-    setAccountInfo(account);
+    const accountRes = await fetchWorkspaceAccount(workspaceId);
+    if (!accountRes) return;
+
+    setAccountInfo(accountRes);
   };
 
   const copyAccountInfo = () => {
@@ -80,7 +89,7 @@ function OrderAccountInfo() {
 
   useEffect(() => {
     getAccountInfo();
-  }, []);
+  }, [account]);
 
   return (
     <Container>

--- a/src/pages/user/order/OrderPay.tsx
+++ b/src/pages/user/order/OrderPay.tsx
@@ -14,6 +14,9 @@ import { useAtom, useAtomValue } from 'jotai';
 import HorizontalDivider from '@components/common/divider/HorizontalDivider';
 import usePreventRefresh from '@hooks/usePreventRefresh';
 import useTossPopup from '@hooks/user/useTossPopup';
+import useWorkspace from '@hooks/user/useWorkspace';
+import { Account } from '@@types/index';
+import { defaultAccountValue } from '@@types/defaultValues';
 
 const Container = styled.div`
   width: 100%;
@@ -50,16 +53,17 @@ function OrderPay() {
   const navigate = useNavigate();
   const { createOrder } = useOrder();
   const { openTossPopupWithPromise } = useTossPopup();
+  const { fetchWorkspaceAccount } = useWorkspace();
   const [searchParams] = useSearchParams();
   const workspaceId = searchParams.get('workspaceId');
   const tableNo = searchParams.get('tableNo');
   const tableHash = searchParams.get('tableHash');
 
-  const account = workspace.owner.account;
-  const tossAccountUrl = account?.tossAccountUrl;
+  const [accountInfo, setAccountInfo] = useState<Account>(defaultAccountValue);
+  const tossAccountUrl = accountInfo?.tossAccountUrl;
   const isTossAvailable = !!tossAccountUrl;
 
-  const [isTossPay, setIsTossPay] = useState<boolean>(isTossAvailable);
+  const [isTossPay, setIsTossPay] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const customerNameRef = useRef<HTMLInputElement>(null);
 
@@ -87,6 +91,15 @@ function OrderPay() {
 
   useEffect(() => {
     customerNameRef.current?.focus();
+
+    fetchWorkspaceAccount(workspaceId).then((account) => {
+      if (account) {
+        setAccountInfo(account);
+        if (account.tossAccountUrl) {
+          setIsTossPay(true);
+        }
+      }
+    });
   }, []);
 
   /**

--- a/src/pages/user/order/OrderWait.tsx
+++ b/src/pages/user/order/OrderWait.tsx
@@ -11,9 +11,9 @@ import HorizontalDivider from '@components/common/divider/HorizontalDivider';
 import { Color } from '@resources/colors';
 import { useEffect, useState } from 'react';
 import useBlockPopState from '@hooks/useBlockPopState';
-import { Order, OrderStatus } from '@@types/index';
+import { Account, Order, OrderStatus } from '@@types/index';
 import useOrder from '@hooks/user/useOrder';
-import { defaultUserOrderValue } from '@@types/defaultValues';
+import { defaultAccountValue, defaultUserOrderValue } from '@@types/defaultValues';
 import { keyframes } from '@emotion/react';
 import useWorkspace from '@hooks/user/useWorkspace';
 import useTossPopup from '@hooks/user/useTossPopup';
@@ -102,14 +102,14 @@ function OrderWait() {
   const orderId = searchParams.get('orderId') || null;
   const isTossPay = searchParams.get('tossPay') === 'true';
 
-  const { fetchWorkspace } = useWorkspace();
+  const { fetchWorkspace, fetchWorkspaceAccount } = useWorkspace();
   const { openTossPopupSync } = useTossPopup();
 
   const workspace = useAtomValue(userWorkspaceAtom);
   const [currentOrder, setCurrentOrder] = useState<Order>(defaultUserOrderValue);
+  const [accountInfo, setAccountInfo] = useState<Account>(defaultAccountValue);
 
-  const account = workspace.owner.account;
-  const tossAccountUrl = account?.tossAccountUrl;
+  const tossAccountUrl = accountInfo?.tossAccountUrl;
 
   const tips = isTossPay ? TOSS_TIPS : BANK_TRANSFER_TIPS;
 
@@ -144,6 +144,9 @@ function OrderWait() {
 
     pollOrder();
     fetchWorkspace(workspaceId);
+    fetchWorkspaceAccount(workspaceId).then((account) => {
+      if (account) setAccountInfo(account);
+    });
 
     intervalId = setInterval(pollOrder, fetchIntervalTime);
 
@@ -184,7 +187,7 @@ function OrderWait() {
       <OrderStickyNavBar useLeftArrow={false} showNavBar={true} workspaceName={workspace.name} tableNo={tableNo} useShareButton={false} />
       <SubContainer className={'order-wait-sub-container'}>
         <ContentsContainer>
-          <OrderAccountInfo />
+          <OrderAccountInfo account={accountInfo} />
           <HorizontalDivider />
           <OrderInfoContainer>
             <Label>송금하실 금액</Label>


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [x] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [x] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?
 
</details>

## 📚 개요

사용자가 워크스페이스의 계좌 정보를 변경했을 때, 이전 계좌 정보가 캐싱되어 있어 새로운 계좌로의 접근이나 입금 확인이 되지 않는 문제를 해결했습니다. 
워크스페이스 전체 정보(`workspace`)에 포함된 사장의 계좌 정보를 참조하는 대신, 결제 및 대기 페이지 진입 시 별도의 계좌 조회 API(`fetchWorkspaceAccount`)를 호출하여 항상 최신의 계좌 데이터를 사용하도록 수정했습니다.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점(Option)

- `OrderPay.tsx`, `OrderWait.tsx`: 페이지 마운트 시 `fetchWorkspaceAccount`를 직접 호출하여 `accountInfo` 상태를 관리합니다. 
- `OrderAccountInfo.tsx`: 부모 컴포넌트로부터 계좌 정보를 props로 전달받을 수 있도록 수정하여 중복 API 호출을 최적화했습니다.