### PR TITLE
ADD - 대학 별 그루핑 및 csv 다운로드 기능 추가

### DIFF
--- a/src/components/super-admin/festival-calendar/FestivalCalendarGrid.tsx
+++ b/src/components/super-admin/festival-calendar/FestivalCalendarGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { RiArrowLeftSLine, RiArrowRightSLine } from '@remixicon/react';
 import styled from '@emotion/styled';
 import FestivalCalendarCell from './FestivalCalendarCell';
@@ -108,6 +108,7 @@ interface FestivalCalendarGridProps {
   onYearChange: (year: number) => void;
   onMonthChange: (month: number) => void;
   onDayClick: (dateStr: string, workspaces: FestivalWorkspace[]) => void;
+  headerAction?: ReactNode;
 }
 
 function buildCalendarDays(year: number, month: number): (number | null)[] {
@@ -119,7 +120,17 @@ function buildCalendarDays(year: number, month: number): (number | null)[] {
   return days;
 }
 
-function FestivalCalendarGrid({ year, month, calendar, onPrevMonth, onNextMonth, onYearChange, onMonthChange, onDayClick }: FestivalCalendarGridProps) {
+function FestivalCalendarGrid({
+  year,
+  month,
+  calendar,
+  onPrevMonth,
+  onNextMonth,
+  onYearChange,
+  onMonthChange,
+  onDayClick,
+  headerAction = null,
+}: FestivalCalendarGridProps) {
   const today = new Date();
   const days = buildCalendarDays(year, month);
   const [yearDraft, setYearDraft] = useState(String(year));
@@ -168,6 +179,7 @@ function FestivalCalendarGrid({ year, month, calendar, onPrevMonth, onNextMonth,
             <RiArrowRightSLine size={18} />
           </NavButton>
         </Controls>
+        {headerAction}
       </Header>
       <WeekdayRow>
         {WEEKDAYS.map((w, i) => (

--- a/src/components/super-admin/festival-calendar/FestivalCsvDownloadButton.tsx
+++ b/src/components/super-admin/festival-calendar/FestivalCsvDownloadButton.tsx
@@ -1,0 +1,65 @@
+import { RiDownload2Line } from '@remixicon/react';
+import styled from '@emotion/styled';
+import { FestivalWorkspaceRankItem } from '@@types/index';
+import { getAdminWorkspacePath } from '@constants/routes';
+import { Color } from '@resources/colors';
+import { rowFlex } from '@styles/flexStyles';
+import { exportToCsv } from '@utils/csv';
+
+const MONTH_PAD_LENGTH = 2;
+
+const CSV_HEADERS = ['대학교', '주점명', '운영자 이름', '운영자 이메일', '주점 Admin URL', '축제 일수', '총 주문', '총 매출'];
+
+const Button = styled.button`
+  gap: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: ${Color.WHITE};
+  background: ${Color.KIO_ORANGE};
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  ${rowFlex({ justify: 'center', align: 'center' })}
+
+  &:hover {
+    background: ${Color.KIO_ORANGE_DARK};
+  }
+
+  &:disabled {
+    background: ${Color.HEAVY_GREY};
+    cursor: not-allowed;
+  }
+`;
+
+interface FestivalCsvDownloadButtonProps {
+  workspaceRanking: FestivalWorkspaceRankItem[];
+  year: number;
+  month: number;
+}
+
+function FestivalCsvDownloadButton({ workspaceRanking, year, month }: FestivalCsvDownloadButtonProps) {
+  const handleDownload = () => {
+    const rows: (string | number)[][] = workspaceRanking.map((workspace) => [
+      workspace.universityName,
+      workspace.workspaceName,
+      workspace.ownerName,
+      workspace.ownerEmail,
+      `${window.location.origin}${getAdminWorkspacePath(workspace.workspaceId)}`,
+      workspace.festivalDays,
+      workspace.totalOrders,
+      workspace.totalRevenue,
+    ]);
+    const fileName = `축제주점_${year}-${String(month).padStart(MONTH_PAD_LENGTH, '0')}.csv`;
+    exportToCsv(fileName, CSV_HEADERS, rows);
+  };
+
+  return (
+    <Button type="button" onClick={handleDownload} disabled={workspaceRanking.length === 0}>
+      <RiDownload2Line size={16} />
+      CSV 다운로드
+    </Button>
+  );
+}
+
+export default FestivalCsvDownloadButton;

--- a/src/components/super-admin/festival-calendar/FestivalUniversityTable.tsx
+++ b/src/components/super-admin/festival-calendar/FestivalUniversityTable.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react';
 import styled from '@emotion/styled';
-import { FestivalUniversityStats } from '@@types/index';
+import { FestivalUniversityStats, FestivalWorkspaceRankItem } from '@@types/index';
 import { Color } from '@resources/colors';
 import { colFlex, rowFlex } from '@styles/flexStyles';
 import { formatCurrency, formatNumber } from '@utils/formatNumber';
+import { getAdminWorkspacePath } from '@constants/routes';
 
 type SortKey = keyof Pick<FestivalUniversityStats, 'universityName' | 'festivalDays' | 'totalOrders' | 'totalRevenue'>;
 type SortDir = 'asc' | 'desc';
@@ -18,7 +20,7 @@ const Wrapper = styled.div`
 
 const TableHeader = styled.div`
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr 1fr 24px;
   padding: 10px 16px;
   background: ${Color.LIGHT_GREY};
   border-bottom: 1px solid ${Color.HEAVY_GREY};
@@ -51,15 +53,18 @@ const SortableHeaderCell = styled.button<{ active: boolean }>`
   }
 `;
 
-const Row = styled.div`
+const Row = styled.div<{ expanded: boolean }>`
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr 1fr 24px;
   padding: 12px 16px;
   border-bottom: 1px solid #f0f0f0;
   align-items: center;
+  cursor: pointer;
+  background: ${({ expanded }) => (expanded ? Color.KIO_ORANGE_FAINT : Color.WHITE)};
+  transition: background 0.15s;
 
-  &:last-child {
-    border-bottom: none;
+  &:hover {
+    background: ${({ expanded }) => (expanded ? Color.KIO_ORANGE_FAINT : Color.LIGHT_GREY)};
   }
 `;
 
@@ -83,6 +88,74 @@ const Rank = styled.span`
   flex-shrink: 0;
 `;
 
+const ExpandIcon = styled.span<{ expanded: boolean }>`
+  color: ${({ expanded }) => (expanded ? Color.KIO_ORANGE : Color.GREY)};
+  transform: rotate(${({ expanded }) => (expanded ? '180deg' : '0deg')});
+  transition: transform 0.15s;
+  ${rowFlex({ justify: 'center', align: 'center' })}
+`;
+
+const ExpandedPanel = styled.div`
+  background: ${Color.KIO_ORANGE_FAINT};
+  border-bottom: 1px solid #f0f0f0;
+  padding-bottom: 8px;
+`;
+
+const PanelCaption = styled.div`
+  font-size: 11px;
+  font-weight: 600;
+  color: ${Color.GREY};
+  letter-spacing: 0.02em;
+  padding: 10px 16px 4px 44px;
+`;
+
+const SubRow = styled.div`
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr 24px;
+  padding: 8px 16px;
+  align-items: center;
+`;
+
+const SubNameCell = styled.div`
+  min-width: 0;
+  padding-left: 28px;
+  gap: 6px;
+  ${rowFlex({ align: 'center' })}
+`;
+
+const SubDot = styled.span`
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: ${Color.KIO_ORANGE};
+  flex-shrink: 0;
+`;
+
+const WorkspaceLink = styled(Link)`
+  font-size: 13px;
+  font-weight: 500;
+  color: ${Color.BLACK};
+  text-decoration: none;
+  word-break: keep-all;
+
+  &:hover {
+    color: ${Color.KIO_ORANGE};
+    text-decoration: underline;
+  }
+`;
+
+const SubCell = styled.div`
+  font-size: 12px;
+  color: ${Color.GREY};
+  word-break: keep-all;
+`;
+
+const SubEmpty = styled.div`
+  font-size: 12px;
+  color: ${Color.GREY};
+  padding: 6px 16px 6px 44px;
+`;
+
 const EmptyRow = styled.div`
   padding: 32px 16px;
   text-align: center;
@@ -104,11 +177,24 @@ function SortArrow({ col, sortKey, sortDir }: SortArrowProps) {
 
 interface FestivalUniversityTableProps {
   universities: FestivalUniversityStats[];
+  workspaces: FestivalWorkspaceRankItem[];
 }
 
-function FestivalUniversityTable({ universities }: FestivalUniversityTableProps) {
+function FestivalUniversityTable({ universities, workspaces }: FestivalUniversityTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>('totalRevenue');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const workspacesByUniversity = useMemo(() => {
+    const grouped = new Map<string, FestivalWorkspaceRankItem[]>();
+    workspaces.forEach((workspace) => {
+      const group = grouped.get(workspace.universityName) ?? [];
+      group.push(workspace);
+      grouped.set(workspace.universityName, group);
+    });
+    grouped.forEach((group) => group.sort((a, b) => b.totalRevenue - a.totalRevenue));
+    return grouped;
+  }, [workspaces]);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -117,6 +203,18 @@ function FestivalUniversityTable({ universities }: FestivalUniversityTableProps)
       setSortKey(key);
       setSortDir('desc');
     }
+  };
+
+  const toggleExpanded = (universityName: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(universityName)) {
+        next.delete(universityName);
+      } else {
+        next.add(universityName);
+      }
+      return next;
+    });
   };
 
   const sorted = [...universities].sort((a, b) => {
@@ -151,17 +249,48 @@ function FestivalUniversityTable({ universities }: FestivalUniversityTableProps)
       {sorted.length === 0 ? (
         <EmptyRow>이번 달 축제 데이터가 없습니다.</EmptyRow>
       ) : (
-        sorted.map((u, idx) => (
-          <Row key={u.universityName}>
-            <NameCell>
-              <Rank>{idx + 1}</Rank>
-              <span>{u.universityName}</span>
-            </NameCell>
-            <Cell>{formatNumber(u.festivalDays)}일</Cell>
-            <Cell>{formatNumber(u.totalOrders)}건</Cell>
-            <Cell>{formatCurrency(u.totalRevenue)}</Cell>
-          </Row>
-        ))
+        sorted.map((u, idx) => {
+          const isExpanded = expanded.has(u.universityName);
+          const universityWorkspaces = workspacesByUniversity.get(u.universityName) ?? [];
+          return (
+            <Fragment key={u.universityName}>
+              <Row expanded={isExpanded} onClick={() => toggleExpanded(u.universityName)}>
+                <NameCell>
+                  <Rank>{idx + 1}</Rank>
+                  <span>{u.universityName}</span>
+                </NameCell>
+                <Cell>{formatNumber(u.festivalDays)}일</Cell>
+                <Cell>{formatNumber(u.totalOrders)}건</Cell>
+                <Cell>{formatCurrency(u.totalRevenue)}</Cell>
+                <ExpandIcon expanded={isExpanded}>
+                  <RiArrowDownSLine size={16} />
+                </ExpandIcon>
+              </Row>
+              {isExpanded && (
+                <ExpandedPanel>
+                  <PanelCaption>운영 주점 {formatNumber(universityWorkspaces.length)}곳</PanelCaption>
+                  {universityWorkspaces.length === 0 ? (
+                    <SubEmpty>주점 정보가 없습니다.</SubEmpty>
+                  ) : (
+                    universityWorkspaces.map((w) => (
+                      <SubRow key={w.workspaceId}>
+                        <SubNameCell>
+                          <SubDot />
+                          <WorkspaceLink to={getAdminWorkspacePath(w.workspaceId)} target="_blank" rel="noopener noreferrer">
+                            {w.workspaceName}
+                          </WorkspaceLink>
+                        </SubNameCell>
+                        <SubCell>{formatNumber(w.festivalDays)}일</SubCell>
+                        <SubCell>{formatNumber(w.totalOrders)}건</SubCell>
+                        <SubCell>{formatCurrency(w.totalRevenue)}</SubCell>
+                      </SubRow>
+                    ))
+                  )}
+                </ExpandedPanel>
+              )}
+            </Fragment>
+          );
+        })
       )}
     </Wrapper>
   );

--- a/src/pages/super-admin/SuperAdminFestivalCalendar.tsx
+++ b/src/pages/super-admin/SuperAdminFestivalCalendar.tsx
@@ -32,11 +32,6 @@ const Sections = styled.div`
   }
 `;
 
-const Toolbar = styled.div`
-  width: 100%;
-  ${rowFlex({ justify: 'flex-end', align: 'center' })}
-`;
-
 const RankingRow = styled.div`
   width: 100%;
   gap: 20px;
@@ -120,9 +115,6 @@ function SuperAdminFestivalCalendar() {
           .with(null, () => <LoadingText>축제 달력 불러오는 중...</LoadingText>)
           .otherwise((loaded) => (
             <Sections>
-              <Toolbar>
-                <FestivalCsvDownloadButton workspaceRanking={loaded.workspaceRanking} year={year} month={month} />
-              </Toolbar>
               <div>
                 <SectionTitle>월별 요약</SectionTitle>
                 <FestivalMonthSummary summary={loaded.monthSummary} />
@@ -136,6 +128,7 @@ function SuperAdminFestivalCalendar() {
                 onYearChange={setYear}
                 onMonthChange={setMonth}
                 onDayClick={handleDayClick}
+                headerAction={<FestivalCsvDownloadButton workspaceRanking={loaded.workspaceRanking} year={year} month={month} />}
               />
               <RankingRow>
                 <RankingColumn>

--- a/src/pages/super-admin/SuperAdminFestivalCalendar.tsx
+++ b/src/pages/super-admin/SuperAdminFestivalCalendar.tsx
@@ -13,6 +13,7 @@ import FestivalMonthSummary from '@components/super-admin/festival-calendar/Fest
 import FestivalUniversityTable from '@components/super-admin/festival-calendar/FestivalUniversityTable';
 import FestivalWorkspaceRankingTable from '@components/super-admin/festival-calendar/FestivalWorkspaceRankingTable';
 import FestivalDayDetail from '@components/super-admin/festival-calendar/FestivalDayDetail';
+import FestivalCsvDownloadButton from '@components/super-admin/festival-calendar/FestivalCsvDownloadButton';
 import useSuperAdminFestivalCalendar from '@hooks/super-admin/useSuperAdminFestivalCalendar';
 import { externalSidebarAtom } from '@jotai/atoms';
 import { FestivalCalendar, FestivalWorkspace, RIGHT_SIDEBAR_ACTION } from '@@types/index';
@@ -29,6 +30,11 @@ const Sections = styled.div`
   ${mobileMediaQuery} {
     gap: 18px;
   }
+`;
+
+const Toolbar = styled.div`
+  width: 100%;
+  ${rowFlex({ justify: 'flex-end', align: 'center' })}
 `;
 
 const RankingRow = styled.div`
@@ -114,6 +120,9 @@ function SuperAdminFestivalCalendar() {
           .with(null, () => <LoadingText>축제 달력 불러오는 중...</LoadingText>)
           .otherwise((loaded) => (
             <Sections>
+              <Toolbar>
+                <FestivalCsvDownloadButton workspaceRanking={loaded.workspaceRanking} year={year} month={month} />
+              </Toolbar>
               <div>
                 <SectionTitle>월별 요약</SectionTitle>
                 <FestivalMonthSummary summary={loaded.monthSummary} />
@@ -131,7 +140,7 @@ function SuperAdminFestivalCalendar() {
               <RankingRow>
                 <RankingColumn>
                   <SectionTitle>대학별 순위</SectionTitle>
-                  <FestivalUniversityTable universities={loaded.universityBreakdown} />
+                  <FestivalUniversityTable universities={loaded.universityBreakdown} workspaces={loaded.workspaceRanking} />
                 </RankingColumn>
                 <RankingColumn>
                   <SectionTitle>주점별 순위</SectionTitle>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -505,6 +505,8 @@ export interface FestivalWorkspaceRankItem {
   workspaceId: number;
   workspaceName: string;
   universityName: string;
+  ownerName: string;
+  ownerEmail: string;
   festivalDays: number;
   totalOrders: number;
   totalRevenue: number;

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,25 @@
+const UTF8_BOM = String.fromCharCode(0xfeff); // UTF-8 BOM (U+FEFF) — 엑셀이 한글을 깨짐 없이 읽게 함
+const CSV_DELIMITER = ',';
+const CSV_LINE_BREAK = '\r\n';
+
+function escapeCsvField(value: string | number): string {
+  const str = String(value);
+  if (/["\r\n,]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function exportToCsv(fileName: string, headers: string[], rows: (string | number)[][]): void {
+  const lines = [headers, ...rows].map((row) => row.map(escapeCsvField).join(CSV_DELIMITER));
+  const content = UTF8_BOM + lines.join(CSV_LINE_BREAK);
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## ✅ 체크리스트
<details>
<summary>체크리스트 확인하기</summary>

 - [x] AppLabel 컴포넌트를 사용하는 부분이 없는가?
 - [ ] ternary 연산자를 사용하는 부분이 존재하지 않는가?
 - [ ] Framentation을 사용하는 부분이 존재하지 않는가?
 - [x] 공통컴포넌트가 아닌 부분에서 Styled prefix를 사용하는 부분이 있는가?
 - [x] 상수화로 선언된 부분을 재사용하고 있는가?
 - [x] rowFlex, colFlex에 대한 style 코드가 가장 하단에 위치하는가?

</details>

## 📚 개요

슈퍼어드민 **축제 달력**에 두 가지 기능을 추가합니다.

1. **대학별 순위 아코디언** — 대학별 순위 행을 클릭하면 그 학교가 운영한 주점 목록(주점명·축제일수·총주문·총매출)이 펼쳐집니다. 어떤 학교에서 어떤 주점이 서비스를 썼는지 한눈에 확인합니다.
2. **현재 달 주점 목록 CSV 다운로드** — 페이지 우상단 `CSV 다운로드` 버튼으로 지금 보고 있는 달의 주점 목록을 8컬럼 CSV로 내려받습니다. 사용 후기 인터뷰 연락·엑셀 정리용입니다.
   - 컬럼: 대학교 / 주점명 / 운영자 이름 / 운영자 이메일 / 주점 Admin URL / 축제 일수 / 총 주문 / 총 매출

범용 `exportToCsv` 유틸(`src/utils/csv.ts`)을 새로 추가했습니다. UTF-8 BOM을 붙여 엑셀에서 한글이 깨지지 않고, 다운로드는 코드베이스 기존 blob 패턴(`utils/qrCode.ts` 등)과 동일합니다.

## 🕐 리뷰 예상 시간

> 10m

## ❗❗ 중요한 변경점(Option)

<img width="1250" height="321" alt="image" src="https://github.com/user-attachments/assets/0e61b9e4-b077-4f17-b10f-628287ab8c23" />

<img width="1321" height="696" alt="image" src="https://github.com/user-attachments/assets/c654f686-0c96-4649-b3a8-63a3589b6823" />

